### PR TITLE
Suppress artifacting in fireplace

### DIFF
--- a/examples/vfx-dynamic-lighting/index.html
+++ b/examples/vfx-dynamic-lighting/index.html
@@ -154,7 +154,7 @@
       new THREE.Vector3(0.3, -1.1, -10.6),
       new THREE.Color(1, 0.95, 0.2),
       1.6,
-      0.9,
+      0,
     );
 
     // ambient light throughout the full room


### PR DESCRIPTION
Set additive opacity to 0 in fireplace so we don't highlight artifacts. Shouldn't really be adding to opacity to the highlight, not a big deal usually but this makes it so only the RGB is changed by the fireplace SDF.

After this change:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/9630d2f5-3f2c-4670-b31a-c978c439c3ee" />

Before this change:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/2f70e71e-217b-4f3a-979d-15c411fefe37" />
