### PR TITLE
Fix FPS controls becoming "sticky" when a blur event occurs

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -186,6 +186,10 @@ export class FpsMovement {
       this.keydown[event.key] = false;
       this.keycode[event.code] = false;
     });
+    window.addEventListener("blur", () => {
+      this.keydown = {};
+      this.keycode = {};
+    });
   }
 
   // Call this method in your render loop with `control` set to the object to control


### PR DESCRIPTION
In the current implementation of the `FpsMovement`, the controls become "sticky" when a blur event occurs. For instance, if I am moving forward in a scene, and a popup occurs or I open a link in a new tab or switch tabs, this causes a `blur` event to occur. If I switch back to the window that lost focus, then I would continue to move forward forever, and the controls "stick" to that direction unless I press the proper direction key again. 

When switching tabs or windows while holding a key, the `keyup` event is not received because the window already loses focus. Therefore, I added a `blur` event listener in `src/controls.ts` to trigger which resets all key states and fixes this issue.