### PR TITLE
Fix snow example

### DIFF
--- a/examples/vfx-particle-simulation/index.html
+++ b/examples/vfx-particle-simulation/index.html
@@ -49,7 +49,6 @@
       0.1,
       1000
     );
-    console.log(camera.position);
 
     const renderer = new THREE.WebGLRenderer();
     renderer.setSize(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
I've fixed the snow example to shift the snowbox, splat, and camera to the origin so the snow particles are less choppy at smaller fall velocity. I've adjusted the snowbox bounds and positions accordingly.