### PR TITLE
Improve rendering of highly-transparent splat scans

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -72,7 +72,7 @@
     import { getAssetFileURL } from "/examples/js/get-asset-url.js";
 
     const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.01, 1000);
     camera.position.set(0, 0, 1);
 
     const canvas = document.getElementById("canvas");
@@ -463,6 +463,7 @@
     gui.add(guiOptions, "stats").name("Show frame stats").onChange((value) => {
       stats.dom.style.display = value ? "block" : "none";
     });
+    gui.add(forge.defaultView, "sortRadial").name("Radial sort").listen();
     gui.add(grid, "opacity", 0, 1, 0.01).name("Grid opacity").listen();
 
     const normalColor = dyno.dynoBool(false);

--- a/src/shaders/splatDefines.glsl
+++ b/src/shaders/splatDefines.glsl
@@ -22,7 +22,7 @@ const float INFINITY = 1.0 / 0.0;
 const float NEG_INFINITY = -INFINITY;
 
 const float MAX_PIXEL_RADIUS = 512.0;
-const float MIN_ALPHA = 0.01;
+const float MIN_ALPHA = 0.5 * (1.0 / 255.0); // 0.00196
 const float MAX_STDDEV = sqrt(8.0);
 
 float sqr(float x) {


### PR DESCRIPTION
In `splatDefines.glsl` we define `MIN_ALPHA = 0.01`, which sets the minimal opacity of a splat before it is culled. This works fine for many splats, but for splat scans that are highly transparent, this means that splats that are below 1% opacity will be culled and never rendered.

Opacity is encoded in a Uint8, which means the lowest encodable value is actually 1/255 =0.00392, so splats with alpha values of 1/255 (0.0039) and 2/255 (0.0078) will simply be discarded. This PR lowers the MIN_ALPHA threshold to 0.5/255 (0.00196), which provides an additional buffer for low-opacity splats allowing them to be rounded up to 1/255.

Before the change:
<img width="730" alt="min_alpha_0 01" src="https://github.com/user-attachments/assets/bb91bb8d-7cde-4f4f-8c42-bfceff240e5e" />

After the change:
<img width="730" alt="min_alpha_0 0019" src="https://github.com/user-attachments/assets/566d63c9-1ac4-4aa3-ae4f-ac2c026be0c4" />

Additionally, added the "sortRadial" option to `examples/editor` to allow users to toggle between Z-depth sorting (more common) and radial sorting (less common, but more stable under rotation). Also lowered Z-near clipping plane in the viewer to 0.01 from 0.1 so smaller scans are easier to see without culling.