### PR TITLE
Add `types` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/spark.cjs.js",
   "module": "./dist/spark.module.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Adds a `types` field to `package.json` so that Node-style module resolution will pick up the types. This is necessary for projects that have `"moduleResolution": "node"` in their `tsconfig.json`.