### PR TITLE
Add preBlurAmount (no AA) and blurAmount (AA) setting sliders to Editor

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -468,11 +468,14 @@
     const normalColor = dyno.dynoBool(false);
     gui.add(normalColor, "value").name("Normal color").onChange(() => updateFrameSplats());
 
+    gui.add(spark, "maxStdDev", 0.1, 3.0, 0.01).name("Max Gsplat stddev").listen();
+    gui.add(spark, "falloff", 0, 1, 0.01).name("Gaussian falloff").listen();
+    gui.add(spark, "preBlurAmount", 0, 2, 0.1).name("Blur amount (no AA)");
+    gui.add(spark, "blurAmount", 0, 2, 0.1).name("Blur amount (AA)");
+
     const splatsFolder = secondGui.addFolder("Files");
 
     const editFolder = gui.addFolder("Edit Splats").close();
-    editFolder.add(spark, "maxStdDev", 0.1, 3.0, 0.01).name("Max Gsplat stddev").listen();
-    editFolder.add(spark, "falloff", 0, 1, 0.01).name("Gaussian falloff").listen();
 
     function updateFrameSplats() {
       frame.children.forEach((child) => {


### PR DESCRIPTION
Add preBlurAmount and blurAmount sliders to examples/editor.
Move other settings out into main right gui panel.

User's screenshot from MKellogg renderer:
![image](https://github.com/user-attachments/assets/348ab9f7-c7ec-4ec6-8a49-ee22101fe43c)

Spark Editor (High DPI enabled, Blur amount (no AA) = 0.3, Blur amount (AA) = 0.0):
![image](https://github.com/user-attachments/assets/9ec4b034-93ac-43c8-ae99-a24d86c1b38d)

Spark Editor (High DPI enabled, Default settings for Blur amount (no AA) = 0.0, Blur amount (AA) = 0.3):
![image](https://github.com/user-attachments/assets/dfc77309-dc85-447e-9f80-89e2b303d516)