### PR TITLE
Fix incorrect SH2 coefficient signs

### DIFF
--- a/src/SplatMesh.ts
+++ b/src/SplatMesh.ts
@@ -717,9 +717,9 @@ const defineEvaluateSH2 = unindent(`
     )) / 127.0;
 
     return sh2_0 * (1.0925484 * viewDir.x * viewDir.y)
-      + sh2_1 * (1.0925484 * viewDir.y * viewDir.z)
+      + sh2_1 * (-1.0925484 * viewDir.y * viewDir.z)
       + sh2_2 * (0.3153915 * (2.0 * viewDir.z * viewDir.z - viewDir.x * viewDir.x - viewDir.y * viewDir.y))
-      + sh2_3 * (1.0925484 * viewDir.x * viewDir.z)
+      + sh2_3 * (-1.0925484 * viewDir.x * viewDir.z)
       + sh2_4 * (0.5462742 * (viewDir.x * viewDir.x - viewDir.y * viewDir.y));
   }
 `);


### PR DESCRIPTION
After going through the spherical harmonics code carefully I realized that two of my SH2 coefficients had the incorrect sign. This seems like it would explain why Victor was seeing only "brightening" with SH2!