### PR TITLE
Change default enable2DGS to false, update docs, improve examples

### DIFF
--- a/docs/docs/spark-renderer.md
+++ b/docs/docs/spark-renderer.md
@@ -35,6 +35,8 @@ const spark = new SparkRenderer({
   enable2DGS?: boolean;
   preBlurAmount?: number;
   blurAmount?: number;
+  focalDistance?: number;
+  apertureAngle?: number;
   falloff?: number;
   clipXY?: number;
   view?: SparkViewpointOptions;
@@ -54,9 +56,11 @@ const spark = new SparkRenderer({
 | **preUpdate**     | Controls whether to update the splats before or after rendering. For WebXR this *must* be false in order to complete rendering as soon as possible. (default: `false`)
 | **originDistance** | Distance threshold for `SparkRenderer` movement triggering a splat update at the new origin. (default: `1.0`) This can be useful when your `SparkRenderer` is a child of your camera and you want to retain high precision coordinates near the camera.
 | **maxStdDev**     | Maximum standard deviations from the center to render Gaussians. Values `Math.sqrt(5)`..`Math.sqrt(9)` produce good results and can be tweaked for performance. (default: `Math.sqrt(8)`)
-| **enable2DGS**    | Enable 2D Gaussian splatting rendering ability. When this mode is enabled, any `scale` x/y/z component that is exactly `0` (minimum quantized value) results in the other two non-zero axes being interpreted as an oriented 2D Gaussian Splat instead of the usual approximate projected 3DGS Z-slice. When reading PLY files, scale values less than e^-20 will be interpreted as `0`. (default: `true`)
+| **enable2DGS**    | Enable 2D Gaussian splatting rendering ability. When this mode is enabled, any `scale` x/y/z component that is exactly `0` (minimum quantized value) results in the other two non-zero axes being interpreted as an oriented 2D Gaussian Splat instead of the usual approximate projected 3DGS Z-slice. When reading PLY files, scale values less than e^-20 will be interpreted as `0`. (default: `false`)
 | **preBlurAmount** | Scalar value to add to 2D splat covariance diagonal, effectively blurring + enlarging splats. In scenes trained without the splat anti-aliasing tweak this value was typically 0.3, but with anti-aliasing it is 0.0 (default: `0.0`)
 | **blurAmount**    | Scalar value to add to 2D splat covariance diagonal, with opacity adjustment to correctly account for "blurring" when anti-aliasing. Typically 0.3 (equivalent to approx 0.5 pixel radius) in scenes trained with anti-aliasing.
+| **focalDistance** | Depth-of-field distance to focal plane (default: `0.0`)
+| **apertureAngle** | Full-width angle of aperture opening from pinhole camera origin in radians (default: `0.0` to disable)
 | **falloff**       | Modulate Gaussian kernel falloff. 0 means "no falloff, flat shading", while 1 is the normal Gaussian kernel. (default: `1.0`)
 | **clipXY**        | X/Y clipping boundary factor for splat centers against view frustum. 1.0 clips any centers that are exactly out of bounds (but the splat's entire projection may still be in bounds), while 1.4 clips centers that are 40% beyond the bounds. (default: `1.4`)
 | **view**          | Configures the `SparkViewpointOptions` for the default `SparkViewpoint` associated with this `SparkRenderer`. Notable option: `sortRadial` (sort by radial distance or Z-depth)

--- a/examples/depth-of-field/index.html
+++ b/examples/depth-of-field/index.html
@@ -41,7 +41,6 @@
         renderer,
         apertureAngle: 0.02,
         focalDistance: 5.0,
-        enable2DGS: false,
     });
     scene.add(spark);
 

--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -14,6 +14,7 @@
       width: 100%;
       height: 100%;
       outline: none; /* Remove default focus outline */
+      touch-action: none;
     }
     #main-gui {
       position: absolute;

--- a/examples/envmap/index.html
+++ b/examples/envmap/index.html
@@ -39,7 +39,7 @@
   </script>
   <script type="module">
     import * as THREE from "three";
-    import { SplatMesh, SparkControls, SparkRenderer } from "@sparkjsdev/spark";
+    import { SplatMesh, SparkRenderer } from "@sparkjsdev/spark";
     import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
     import { getAssetFileURL } from "/examples/js/get-asset-url.js";
 

--- a/examples/procedural-splats/index.html
+++ b/examples/procedural-splats/index.html
@@ -8,6 +8,9 @@
     body {
       margin: 0;
     }
+    canvas {
+      touch-action: none;
+    }
   </style>
 </head>
 
@@ -28,7 +31,6 @@
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
     const renderer = new THREE.WebGLRenderer();
-    renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(window.innerWidth, window.innerHeight);
     document.body.appendChild(renderer.domElement)
 

--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -105,7 +105,7 @@ export type SparkRendererOptions = {
   // any scale x/y/z component that is exactly 0 (minimum quantized value) results
   // in the other two non-0 axis being interpreted as an oriented 2D Gaussian Splat,
   // rather instead of the usual projected 3DGS Z-slice. When reading PLY files,
-  // scale values less than e^-20 will be interpreted as 0. (default: true)
+  // scale values less than e^-20 will be interpreted as 0. (default: false)
   enable2DGS?: boolean;
   // Scalar value to add to 2D splat covariance diagonal, effectively blurring +
   // enlarging splats. In scenes trained without the Gsplat anti-aliasing tweak
@@ -244,7 +244,7 @@ export class SparkRenderer extends THREE.Mesh {
     this.preUpdate = options.preUpdate ?? false;
     this.originDistance = options.originDistance ?? 1;
     this.maxStdDev = options.maxStdDev ?? Math.sqrt(8.0);
-    this.enable2DGS = options.enable2DGS ?? true;
+    this.enable2DGS = options.enable2DGS ?? false;
     this.preBlurAmount = options.preBlurAmount ?? 0.0;
     this.blurAmount = options.blurAmount ?? 0.3;
     this.focalDistance = options.focalDistance ?? 0.0;


### PR DESCRIPTION
Since 2DGS is a more niche rendering technique still, change the default `enable2DGS` to `false` so people don't accidentally render very flat/thin splats via 2DGS coordinates instead of the 3DGS interpretation. I was seeing this problem with the WebXR/DoF example town scene where some of the splats were so thin they were being rendered as 2DGS (this happens when one of scale_x/y/z = 0 exactly). If people specifically have 2DGS data they will likely know this and can turn on the flag. Updated docs accordingly and also added the depth-of-field settings for SparkRenderer docs.

The procedural-splats example was running poorly on Android, so I turned off high DPI for it. In some of the examples touch controls were not working because the canvas was taking the touch controls and scrolling the pane instead.