### PR TITLE
Use `getDrawingBufferSize` to determine renderer size

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -418,16 +418,7 @@ export class SparkRenderer extends THREE.Mesh {
       );
     } else {
       // Rendering to the canvas or WebXR
-      const renderSize = renderer.getSize(this.uniforms.renderSize.value);
-      if (renderSize.x === 1 && renderSize.y === 1) {
-        // WebXR mode on Apple Vision Pro returns 1x1 when presenting.
-        // Use a different means to figure out the render size.
-        const baseLayer = renderer.xr.getSession()?.renderState.baseLayer;
-        if (baseLayer) {
-          renderSize.x = baseLayer.framebufferWidth;
-          renderSize.y = baseLayer.framebufferHeight;
-        }
-      }
+      renderer.getDrawingBufferSize(this.uniforms.renderSize.value);
     }
 
     // Update uniforms from instance properties


### PR DESCRIPTION
The `rendererSize` was retrieved using `WebGLRenderer.getSize(target)`. However, this method returns the size in _logical pixels_, whereas the actual size in _physical pixels_ is needed. Using `getDrawingBufferSize` resolves this issue and returns the correct value for High-DPI displays (when `pixelRatio != 1`) and during WebXR sessions (both with and without WebXR Layers)

The AVP specific workaround puzzles me a bit. Unless this was written against an old version of Three.js, the size should be kept in sync. So `getSize()` returning `1x1` would imply a `1x1` render target being created for WebXR, which would be entirely unusable. @dmarcos  Could you verify that rendering on an AVP works with these changes and that the workaround is no longer needed?