### PR TITLE
Fix compressed PLY loading from older versions of SS.

### DIFF
--- a/src/ply.ts
+++ b/src/ply.ts
@@ -326,12 +326,6 @@ export class PlyReader {
         max_scale_x,
         max_scale_y,
         max_scale_z,
-        min_r,
-        min_g,
-        min_b,
-        max_r,
-        max_g,
-        max_b,
       } = element.properties;
       if (
         !min_x ||
@@ -345,13 +339,7 @@ export class PlyReader {
         !min_scale_z ||
         !max_scale_x ||
         !max_scale_y ||
-        !max_scale_z ||
-        !min_r ||
-        !min_g ||
-        !min_b ||
-        !max_r ||
-        !max_g ||
-        !max_b
+        !max_scale_z
       ) {
         throw new Error("Missing PLY chunk properties");
       }
@@ -490,11 +478,16 @@ export class PlyReader {
         );
 
         const r =
-          (((packed_color >>> 24) & 255) / 255) * (max_r - min_r) + min_r;
+          (((packed_color >>> 24) & 255) / 255) *
+            ((max_r ?? 1) - (min_r ?? 0)) +
+          (min_r ?? 0);
         const g =
-          (((packed_color >>> 16) & 255) / 255) * (max_g - min_g) + min_g;
+          (((packed_color >>> 16) & 255) / 255) *
+            ((max_g ?? 1) - (min_g ?? 0)) +
+          (min_g ?? 0);
         const b =
-          (((packed_color >>> 8) & 255) / 255) * (max_b - min_b) + min_b;
+          (((packed_color >>> 8) & 255) / 255) * ((max_b ?? 1) - (min_b ?? 0)) +
+          (min_b ?? 0);
         const opacity = (packed_color & 255) / 255;
 
         splatCallback(
@@ -919,10 +912,10 @@ type SSChunk = {
   max_scale_x: number;
   max_scale_y: number;
   max_scale_z: number;
-  min_r: number;
-  min_g: number;
-  min_b: number;
-  max_r: number;
-  max_g: number;
-  max_b: number;
+  min_r?: number;
+  min_g?: number;
+  min_b?: number;
+  max_r?: number;
+  max_g?: number;
+  max_b?: number;
 };


### PR DESCRIPTION
From this file: https://github.com/user-attachments/files/20961347/baltimore.ps.cleaned.compressed2.ply.zip
Looking at the PLY header we see this:
```
ply
format binary_little_endian 1.0
comment Generated by SuperSplat 1.8.3
element chunk 2626
property float min_x
property float min_y
property float min_z
property float max_x
property float max_y
property float max_z
property float min_scale_x
property float min_scale_y
property float min_scale_z
property float max_scale_x
property float max_scale_y
property float max_scale_z
element vertex 672077
property uint packed_position
property uint packed_rotation
property uint packed_scale
property uint packed_color
end_header
```

Interestingly for newer exports for SS compressed PLY the header looks like this:
```
ply
format binary_little_endian 1.0
comment Generated by SuperSplat 2.4.1
element chunk 31171
property float min_x
property float min_y
property float min_z
property float max_x
property float max_y
property float max_z
property float min_scale_x
property float min_scale_y
property float min_scale_z
property float max_scale_x
property float max_scale_y
property float max_scale_z
property float min_r
property float min_g
property float min_b
property float max_r
property float max_g
property float max_b
element vertex 7979586
property uint packed_position
property uint packed_rotation
property uint packed_scale
property uint packed_color
```

So newer exports from SS of compressed PLY also include min/max_r/g/b in their chunk properties, while older SS (possibly 1.* instead of 2.*?) don't include it. Looking through PlayCanvas sources it seems that if they aren't specified we simply assume min/max = 0/1 for those properties.

Loading it in Spark Editor vs. Super Splat appears to validate this approach. I'm able to load the above mentioned file in Spark without a problem now. This addresses the particular file loading issue in #72 .