### PR TITLE
Fix Download SPZ button in Viewer when loading splat from URL

### DIFF
--- a/examples/viewer/index.html
+++ b/examples/viewer/index.html
@@ -287,11 +287,18 @@
     if (splatURL) { loadSplatURL(splatURL); }
 
 
-    function loadSplatURL(splatURL) {
+    async function loadSplatURL(splatURL) {
       fileName = splatURL.split("/").pop().split("?")[0];
       document.querySelector('.container').classList.add('hidden');
       document.querySelector('.canvas-container').classList.remove('invisible');
-      setSplatFile({ url: splatURL });
+      const response = await fetch(splatURL);
+      if (response.ok) {
+        fileBytes = new Uint8Array(await response.arrayBuffer());
+        setSplatFile({ fileBytes: fileBytes.slice(), fileName });
+      } else {
+        console.error("Failed to load splat file from URL:", splatURL);
+        return;
+      }
     }
 
     const urlFormEl = document.querySelector('.url-form');


### PR DESCRIPTION
In Viewer, when the splat is loaded from URL, clicking on the download spz button throws the following error:
<img width="509" alt="Screenshot 2025-07-02 at 12 26 28" src="https://github.com/user-attachments/assets/ee1fd942-1f06-43a2-8384-fbd8a9a60dc6" />

This PR fixes the issue.