### PR TITLE
Use OffscreenCanvas and WebGL2 context to decode webp images for SOGS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "@jsquash/webp": "^1.5.0",
         "fflate": "^0.8.2"
       },
       "devDependencies": {
@@ -705,15 +704,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@jsquash/webp": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jsquash/webp/-/webp-1.5.0.tgz",
-      "integrity": "sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "wasm-feature-detect": "^1.2.11"
       }
     },
     "node_modules/@microsoft/api-extractor": {
@@ -2899,12 +2889,6 @@
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/wasm-feature-detect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
-      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "spark-internal-rs": "file:rust/spark-internal-rs/pkg"
   },
   "dependencies": {
-    "@jsquash/webp": "^1.5.0",
     "fflate": "^0.8.2"
   },
   "keywords": ["3d", "three.js", "gsplats", "3dgs", "gaussian", "splats"]


### PR DESCRIPTION
For SOGS support (#73) a dependency was introduced to decode the webp images to access the raw RGBA pixel data. This PR replaces the dependency with using a WebGL context to read back the pixel data. This has the benefit of utilizing the browser's built-in image decoding.

There is the possible downside that browser implementation differences could lead to different result or that WebGL limitations on the device (e.g. max texture size) could limit which files can be decoded.