### PR TITLE
Exclude local assets directory from linting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -9,6 +9,7 @@
     "ignoreUnknown": false,
     "ignore": [
       "dist/*",
+      "examples/assets/",
       "examples/showcase/hello-gsplat",
       "rust/target",
       "rust/spark-internal-rs/pkg",


### PR DESCRIPTION
After adding a splat using the SOGS file format to the local asset directory for testing, the `biome` linter started reporting on formatting issues for the `meta.json` file. Since the local assets directory is excluded by the `.gitignore` file already, it only makes sense to exclude it from linting as well.