### PR TITLE
PC SOGS decoding from .Zip archive

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -63,7 +63,7 @@
   <canvas id="canvas" tabindex="0"></canvas>
   <div id="main-gui"></div>
   <div id="second-gui"></div>
-  <input id="file-input" type="file" accept=".ply,.spz,.splat,.ksplat" multiple="true" style="display: none;" />
+  <input id="file-input" type="file" accept=".ply,.spz,.splat,.ksplat,.zip" multiple="true" style="display: none;" />
   <script type="module">
     import * as THREE from "three";
     import { OrbitControls } from "three/addons/controls/OrbitControls.js";
@@ -154,7 +154,7 @@
             loadFiles(urls);
             guiOptions.loadFromText = ""; // Clear after loading
           } else {
-            alert("No valid URLs found in text. URLs must start with http:// or https:// and end with .ply, .spz, .splat, .ksplat, or .json");
+            alert("No valid URLs found in text. URLs must start with http:// or https:// and end with .ply, .spz, .splat, .ksplat, .json, or .zip");
           }
         }
       },
@@ -683,7 +683,8 @@
         file.name.toLowerCase().endsWith('.ply') ||
         file.name.toLowerCase().endsWith('.spz') ||
         file.name.toLowerCase().endsWith('.splat') ||
-        file.name.toLowerCase().endsWith('.ksplat')
+        file.name.toLowerCase().endsWith('.ksplat') ||
+        file.name.toLowerCase().endsWith('.zip')
       );
 
       if (splatFiles.length > 0) {
@@ -693,7 +694,7 @@
 
     // Parse URLs from text (handles single URLs, multiple lines, mixed content)
     function parseURLsFromText(text) {
-      const supportedExtensions = [".ply", ".spz", ".splat", ".ksplat", ".json"];
+      const supportedExtensions = [".ply", ".spz", ".splat", ".ksplat", ".zip", ".json"];
       const urls = [];
 
       // Split by lines, commas, and semicolons

--- a/examples/viewer/index.html
+++ b/examples/viewer/index.html
@@ -347,7 +347,7 @@
       </div>
       <div class="drop-zone">Drag and drop a splat file here</div>
       <label for="file-input" class="button upload"><img class="upload-icon" src="upload-icon.svg" alt="upload" />Choose file</label>
-      <input id="file-input" class="hidden" accept=".ply,.spz,.splat,.ksplat" type="file" />
+      <input id="file-input" class="hidden" accept=".ply,.spz,.splat,.ksplat,.zip" type="file" />
       <form class="url-form">
         <input class="url-input" type="text" placeholder="Copy splat URL" />
       </form>

--- a/src/pcsogs.ts
+++ b/src/pcsogs.ts
@@ -1,4 +1,3 @@
-import { decode as decodeWebp } from "@jsquash/webp";
 import { unzip } from "fflate";
 import { type PcSogsJson, tryPcSogsZip } from "./SplatLoader";
 import {
@@ -149,9 +148,56 @@ export async function unpackPcSogs(
   return { packedArray, numSplats, extra };
 }
 
+// WebGL context for reading raw pixel data of WebP images
+let offscreenGlContext: WebGL2RenderingContext | null = null;
+
 async function decodeImage(fileBytes: ArrayBuffer) {
-  const { data: rgba, width, height } = await decodeWebp(fileBytes);
-  return { rgba, width, height };
+  if (!offscreenGlContext) {
+    const canvas = new OffscreenCanvas(1, 1);
+    offscreenGlContext = canvas.getContext("webgl2");
+    if (!offscreenGlContext) {
+      throw new Error("Failed to create WebGL2 context");
+    }
+  }
+
+  const imageBlob = new Blob([fileBytes]);
+  const bitmap = await createImageBitmap(imageBlob, {
+    premultiplyAlpha: "none",
+  });
+
+  const gl = offscreenGlContext;
+  const texture = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmap);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+
+  const framebuffer = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+  gl.framebufferTexture2D(
+    gl.FRAMEBUFFER,
+    gl.COLOR_ATTACHMENT0,
+    gl.TEXTURE_2D,
+    texture,
+    0,
+  );
+
+  const data = new Uint8Array(bitmap.width * bitmap.height * 4);
+  gl.readPixels(
+    0,
+    0,
+    bitmap.width,
+    bitmap.height,
+    gl.RGBA,
+    gl.UNSIGNED_BYTE,
+    data,
+  );
+
+  gl.deleteTexture(texture);
+  gl.deleteFramebuffer(framebuffer);
+
+  return { rgba: data, width: bitmap.width, height: bitmap.height };
 }
 
 async function decodeImageRgba(fileBytes: ArrayBuffer) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,9 +1,9 @@
 import init_wasm, { sort_splats } from "spark-internal-rs";
-import type { TranscodeSpzInput } from "./SplatLoader";
+import type { PcSogsJson, TranscodeSpzInput } from "./SplatLoader";
 import { unpackAntiSplat } from "./antisplat";
 import { SCALE_MIN, WASM_SPLAT_SORT } from "./defines";
 import { unpackKsplat } from "./ksplat";
-import { unpackPcSogs } from "./pcsogs";
+import { unpackPcSogs, unpackPcSogsZip } from "./pcsogs";
 import { PlyReader } from "./ply";
 import { SpzReader, transcodeSpz } from "./spz";
 import {
@@ -86,7 +86,21 @@ async function onMessage(event: MessageEvent) {
           fileBytes: Uint8Array;
           extraFiles: Record<string, ArrayBuffer>;
         };
-        const decoded = await unpackPcSogs(fileBytes, extraFiles);
+        const json = JSON.parse(
+          new TextDecoder().decode(fileBytes),
+        ) as PcSogsJson;
+        const decoded = await unpackPcSogs(json, extraFiles);
+        result = {
+          id,
+          numSplats: decoded.numSplats,
+          packedArray: decoded.packedArray,
+          extra: decoded.extra,
+        };
+        break;
+      }
+      case "decodePcSogsZip": {
+        const { fileBytes } = args as { fileBytes: Uint8Array };
+        const decoded = await unpackPcSogsZip(fileBytes);
         result = {
           id,
           numSplats: decoded.numSplats,


### PR DESCRIPTION
Implement PC SOGS decoding from .zip file archive.
Updates viewer and editor to accept .zip files.

Reuses the existing dependency `fflate` decode a .zip file containing `meta.json` and WEBP image files referenced from it. Note that this works whether `meta.json` and the images are at the root of the archive, or if they are contained within some `subfolder/meta.json` - the decoder will grab the prefix of the first `meta.json` it sees and uses image files relative from that.

Here's a scan I did you can try: 
[canapes-mcmc-250k-30k.zip](https://github.com/user-attachments/files/21111735/canapes-mcmc-250k-30k.zip)

Any folder output zipped from the PlayCanvas SOGS package should work, and is a nicer interface to work with because you can drag-and-drop SOGS files into the viewer/editor.
<img width="1319" alt="image" src="https://github.com/user-attachments/assets/916ee6e3-3b03-42a0-bccc-2ba01472abde" />
