### PR TITLE
DRAFT: Adjust focal and ndcOffset computations

### DIFF
--- a/src/shaders/splatVertex.glsl
+++ b/src/shaders/splatVertex.glsl
@@ -113,7 +113,7 @@ void main() {
 
     // Compute the Jacobian of the splat's projection at its center
     vec2 scaledRenderSize = renderSize * renderScale;
-    vec2 focal = 0.5 * scaledRenderSize * vec2(projectionMatrix[0][0], projectionMatrix[1][1]);
+    vec2 focal = scaledRenderSize * vec2(projectionMatrix[0][0], projectionMatrix[1][1]);
     float invZ = 1.0 / viewCenter.z;
     vec2 J1 = focal * invZ;
     vec2 J2 = -(J1 * viewCenter.xy) * invZ;
@@ -177,7 +177,7 @@ void main() {
 
     // Compute the NDC coordinates for the ellipsoid's diagonal axes.
     vec2 pixelOffset = eigenVec1 * scale1 + eigenVec2 * scale2;
-    vec2 ndcOffset = (2.0 / scaledRenderSize) * pixelOffset;
+    vec2 ndcOffset = pixelOffset / scaledRenderSize;
     vec3 ndc = vec3(ndcCenter.xy + ndcOffset, ndcCenter.z);
 
     vRgba = rgba;


### PR DESCRIPTION
This PR is mostly for demonstration purposes. The changes bring the behaviour in line with SuperSplat, generally resulting in sharper results. However, I believe these changes are technically not correct, despite the subjectively better visuals.

It's worth noting the Mkkellogg's renderer has a [`focalAdjustment` parameter](https://github.com/mkkellogg/GaussianSplats3D/blob/2dfc83e497bd76e558fe970c54464b17b5f5c689/src/splatmesh/SplatMaterial3D.js#L206-L207) that also tweaks this behaviour, quoting the docs:

>  `focalAdjustment`: Hacky, non-scientific parameter for tweaking focal length related calculations. For scenes with very small gaussians & small details, increasing this value can help improve visual quality. Default value is 1.0.

So it might be worthwhile to consider a similar biased/subjective option. Of course, some additional scrutiny to the logic to ensure the current implementation _is_ correct would be appreciated. Given these changes match the SuperSplat behaviour, one or the other must be doing something "wrong" (deliberate or not).