### PR TITLE
Add background color selector to examples/editor.

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -485,6 +485,8 @@
       spark.focalDistance = Math.exp(value);
     });
     gui.add(spark, "apertureAngle", 0, 0.01 * Math.PI, 0.001).name("Aperture angle").listen();
+    scene.background = new THREE.Color(0, 0, 0);
+    gui.addColor(scene, "background").name("Background color").listen();
 
     const debugFolder = gui.addFolder("Debug").close();
     const normalColor = dyno.dynoBool(false);


### PR DESCRIPTION
This PR adds a background color selection option to examples/editor, defaulted to black.

<img width="288" alt="image" src="https://github.com/user-attachments/assets/c3c5a40b-18bc-4756-ab5d-47e6c4595fb3" />
