### PR TITLE
DRAFT. Prevent default wasm-pack behavior when fetching .wasm files via new URL that seems to confuse Webpack (fix #97, fix #95)

### DIFF
--- a/src/SplatMesh.ts
+++ b/src/SplatMesh.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 
 import init_wasm, { raycast_splats } from "spark-internal-rs";
+import wasmURL from "spark-internal-rs/spark_internal_rs_bg.wasm?url";
 import { PackedSplats } from "./PackedSplats";
 import { type RgbaArray, readRgbaArray } from "./RgbaArray";
 import { SplatEdit, SplatEditSdf, SplatEdits } from "./SplatEdit";
@@ -252,7 +253,9 @@ export class SplatMesh extends SplatGenerator {
   static dynoTime = new DynoFloat({ value: 0 });
 
   static async staticInitialize() {
-    await init_wasm();
+    const response = await fetch(wasmURL);
+    const wasmBytes = new Uint8Array(await response.arrayBuffer());
+    await init_wasm({ wasm: wasmBytes });
     SplatMesh.isStaticInitialized = true;
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,4 +1,5 @@
 import init_wasm, { sort_splats } from "spark-internal-rs";
+import wasmURL from "spark-internal-rs/spark_internal_rs_bg.wasm?url";
 import type { PcSogsJson, TranscodeSpzInput } from "./SplatLoader";
 import { unpackAntiSplat } from "./antisplat";
 import { SCALE_MIN, WASM_SPLAT_SORT } from "./defines";
@@ -441,8 +442,9 @@ function bufferMessage(event: MessageEvent) {
 async function initialize() {
   // Hold any messages received while initializing
   self.addEventListener("message", bufferMessage);
-
-  await init_wasm();
+  const response = await fetch(wasmURL);
+  const wasmBytes = new Uint8Array(await response.arrayBuffer());
+  await init_wasm({ wasm: wasmBytes });
 
   self.removeEventListener("message", bufferMessage);
   self.addEventListener("message", onMessage);


### PR DESCRIPTION
Don't merge. tentative solution. needs verification.