### PR TITLE
Rename SparkRenderer.renderScale to focalAdjustment. 

### DIFF
--- a/docs/docs/spark-renderer.md
+++ b/docs/docs/spark-renderer.md
@@ -39,6 +39,7 @@ const spark = new SparkRenderer({
   apertureAngle?: number;
   falloff?: number;
   clipXY?: number;
+  focalAdjustment?: number;
   view?: SparkViewpointOptions;
 });
 ```
@@ -63,6 +64,7 @@ const spark = new SparkRenderer({
 | **apertureAngle** | Full-width angle of aperture opening from pinhole camera origin in radians (default: `0.0` to disable)
 | **falloff**       | Modulate Gaussian kernel falloff. 0 means "no falloff, flat shading", while 1 is the normal Gaussian kernel. (default: `1.0`)
 | **clipXY**        | X/Y clipping boundary factor for splat centers against view frustum. 1.0 clips any centers that are exactly out of bounds (but the splat's entire projection may still be in bounds), while 1.4 clips centers that are 40% beyond the bounds. (default: `1.4`)
+| **focalAdjustment** | Parameter to adjust projected splat scale calculation to match other renderers, similar to the same parameter in the MKellogg 3DGS renderer. Higher values will tend to sharpen the splats. A value 2.0 can be used to match the behavior of the PlayCanvas renderer.  (default: `1.0`)
 | **view**          | Configures the `SparkViewpointOptions` for the default `SparkViewpoint` associated with this `SparkRenderer`. Notable option: `sortRadial` (sort by radial distance or Z-depth)
 
 ## `newViewpoint(options: SparkViewpointOptions)`

--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -512,7 +512,7 @@
         spark.blurAmount = 0.3;
       },
     }, "AA").name("AA preset");
-    debugFolder.add(spark, "renderScale", 0.1, 2.0, 0.1).name("Render scale");
+    debugFolder.add(spark, "focalAdjustment", 0.1, 2.0, 0.1).name("Tweak focalAdjustment");
 
     const splatsFolder = secondGui.addFolder("Files");
 

--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -126,6 +126,11 @@ export type SparkRendererOptions = {
   // 1.0 clips any centers that are exactly out of bounds, while 1.4 clips
   // centers that are 40% beyond the bounds. (default: 1.4)
   clipXY?: number;
+  // Parameter to adjust projected splat scale calculation to match other renderers,
+  // similar to the same parameter in the MKellogg 3DGS renderer. Higher values will
+  // tend to sharpen the splats. A value 2.0 can be used to match the behavior of
+  // the PlayCanvas renderer. (default: 1.0)
+  focalAdjustment?: number;
   // Configures the SparkViewpointOptions for the default SparkViewpoint
   // associated with this SparkRenderer. Notable option: sortRadial (sort by
   // radial distance or Z-depth)
@@ -148,7 +153,7 @@ export class SparkRenderer extends THREE.Mesh {
   apertureAngle: number;
   falloff: number;
   clipXY: number;
-  renderScale = 1.0;
+  focalAdjustment: number;
 
   splatTexture: null | {
     enable?: boolean;
@@ -264,6 +269,7 @@ export class SparkRenderer extends THREE.Mesh {
     this.apertureAngle = options.apertureAngle ?? 0.0;
     this.falloff = options.falloff ?? 1.0;
     this.clipXY = options.clipXY ?? 1.4;
+    this.focalAdjustment = options.focalAdjustment ?? 1.0;
 
     this.active = new SplatAccumulator();
     this.accumulatorCount = 1;
@@ -321,7 +327,7 @@ export class SparkRenderer extends THREE.Mesh {
       // Clip Gsplats that are clipXY times beyond the +-1 frustum bounds
       clipXY: { value: 1.4 },
       // Debug renderSize scale factor
-      renderScale: { value: 1.0 },
+      focalAdjustment: { value: 1.0 },
       // Enable splat texture rendering
       splatTexEnable: { value: false },
       // Splat texture to render
@@ -479,7 +485,7 @@ export class SparkRenderer extends THREE.Mesh {
     this.uniforms.apertureAngle.value = this.apertureAngle;
     this.uniforms.falloff.value = this.falloff;
     this.uniforms.clipXY.value = this.clipXY;
-    this.uniforms.renderScale.value = this.renderScale;
+    this.uniforms.focalAdjustment.value = this.focalAdjustment;
 
     if (this.splatTexture) {
       const { enable, texture, multiply, add, near, far, mid } =

--- a/src/shaders/splatVertex.glsl
+++ b/src/shaders/splatVertex.glsl
@@ -25,7 +25,7 @@ uniform float preBlurAmount;
 uniform float focalDistance;
 uniform float apertureAngle;
 uniform float clipXY;
-uniform float renderScale;
+uniform float focalAdjustment;
 
 uniform usampler2DArray packedSplats;
 
@@ -112,7 +112,7 @@ void main() {
     mat3 cov3D = RS * transpose(RS);
 
     // Compute the Jacobian of the splat's projection at its center
-    vec2 scaledRenderSize = renderSize * renderScale;
+    vec2 scaledRenderSize = renderSize * focalAdjustment;
     vec2 focal = 0.5 * scaledRenderSize * vec2(projectionMatrix[0][0], projectionMatrix[1][1]);
     float invZ = 1.0 / viewCenter.z;
     vec2 J1 = focal * invZ;


### PR DESCRIPTION
Also added to constructor options for initialization and to docs. Included note about how it's similar to the same `focalAdjustment` parameter in MKellogg, and that a value of 2.0 matches the calculations in the PlayCanvas engine.

This PR subsumes #102 by providing a parameter that people can use to adjust to their liking. This potentially fixes #99 but it will be up to the user to decide if these tweaks are enough to match their expectation.