### PR TITLE
Perform more tree-shaking on worker code

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,6 +90,9 @@ export default defineConfig(({ mode }) => {
     },
 
     worker: {
+      rollupOptions: {
+        treeshake: "smallest",
+      },
       plugins: () => [
         glsl({
           include: ["**/*.glsl"],


### PR DESCRIPTION
The bundle size of spark is 810 KB (for `spark.module.min.js`). Inspecting the source map reveals that there is quite a lot of duplication in the bundle. The bundle contains the main source, as well as the worker source code. Since these two are effectively separate, any code referenced by both ends up twice in the final bundle. This includes the `spark-internal-rs` sub-project with its WASM blob being included twice.

On the worker side it turns out that it pulls in various parts of the user-facing classes (`SplatMesh`, `SplatEdit`, `SplatLoader`), dyno classes/functions as well as various parts of Three.js.

This PR configures Vite to perform more aggressive tree-shaking on the worker bundle. As a result many of the above mentioned chunks are no longer included in the worker source bundle (as they weren't _actually_ needed in the first place). With this change the bundle size drops to ≈651 KB.

Ultimately it would be beneficial to make the separation between worker code and the main library code clearer. This can avoid situations where the two starts pulling in each-others code. Additionally the `@__PURE__` and `@__NO_SIDE_EFFECTS__` annotations can be used to make the tree-shaking easier (and "safer").