### PR TITLE
Draft: Expand splat represention to 32 bytes using two array texture targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "onchange": "7.1.0",
         "spark-internal-rs": "file:rust/spark-internal-rs/pkg",
         "stats.js": "^0.17.0",
-        "three": "^0.172.0",
+        "three": "git+https://github.com/mrxz/three.js.git#array-texture-mrt-build",
         "ts-node": "10.9.2",
         "typescript": "^5.7.3",
         "vite": "^6.0.11",
@@ -2623,9 +2623,8 @@
       }
     },
     "node_modules/three": {
-      "version": "0.172.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
-      "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==",
+      "version": "0.178.0",
+      "resolved": "git+ssh://git@github.com/mrxz/three.js.git#bc2d35e0b7c33c4fd9d3f7ef58a6765f9527adbf",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     "lefthook": "1.11.12",
     "lil-gui": "^0.20.0",
     "onchange": "7.1.0",
+    "spark-internal-rs": "file:rust/spark-internal-rs/pkg",
     "stats.js": "^0.17.0",
-    "three": "^0.172.0",
+    "three": "git+https://github.com/mrxz/three.js.git#array-texture-mrt-build",
     "ts-node": "10.9.2",
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-glsl": "^1.3.1",
-    "spark-internal-rs": "file:rust/spark-internal-rs/pkg"
+    "vite-plugin-glsl": "^1.3.1"
   },
   "dependencies": {
     "fflate": "^0.8.2"

--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -265,6 +265,7 @@ export class SparkRenderer extends THREE.Mesh {
       uniforms,
       transparent: true,
       blending: THREE.NormalBlending,
+      premultipliedAlpha: true,
       depthTest: true,
       depthWrite: false,
       side: THREE.DoubleSide,
@@ -382,7 +383,8 @@ export class SparkRenderer extends THREE.Mesh {
       // Splat texture mid plane distance, or 0.0 to disable
       splatTexMid: { value: 0.0 },
       // Gsplat collection to render
-      packedSplats: { type: "t", value: PackedSplats.getEmpty() },
+      packedSplats: { type: "t", value: PackedSplats.getEmpty()[0] },
+      packedSplats2: { type: "t", value: PackedSplats.getEmpty()[1] },
       // Time in seconds for time-based effects
       time: { value: 0 },
       // Delta time in seconds since last frame
@@ -577,12 +579,14 @@ export class SparkRenderer extends THREE.Mesh {
     if (this.viewpoint.display) {
       const { accumulator, geometry } = this.viewpoint.display;
       this.uniforms.numSplats.value = accumulator.splats.numSplats;
-      this.uniforms.packedSplats.value = accumulator.splats.getTexture();
+      this.uniforms.packedSplats.value = accumulator.splats.getTexture()[0];
+      this.uniforms.packedSplats2.value = accumulator.splats.getTexture()[1];
       this.geometry = geometry;
     } else {
       // No Gsplats to display for this viewpoint yet
       this.uniforms.numSplats.value = 0;
-      this.uniforms.packedSplats.value = PackedSplats.getEmpty();
+      this.uniforms.packedSplats.value = PackedSplats.getEmpty()[0];
+      this.uniforms.packedSplats2.value = PackedSplats.getEmpty()[1];
       this.geometry = EMPTY_GEOMETRY;
     }
   }

--- a/src/SplatLoader.ts
+++ b/src/SplatLoader.ts
@@ -402,7 +402,7 @@ export async function unpackSplats({
   fileType?: SplatFileType;
   pathOrUrl?: string;
 }): Promise<{
-  packedArray: Uint32Array;
+  packedArray: [Uint32Array, Uint32Array];
   numSplats: number;
   extra?: Record<string, unknown>;
 }> {
@@ -422,13 +422,19 @@ export async function unpackSplats({
       await ply.parseHeader();
       const numSplats = ply.numSplats;
       const maxSplats = getTextureSize(numSplats).maxSplats;
-      const args = { fileBytes, packedArray: new Uint32Array(maxSplats * 4) };
+      const args = {
+        fileBytes,
+        packedArray: [
+          new Uint32Array(maxSplats * 4),
+          new Uint32Array(maxSplats * 4),
+        ],
+      };
       return await withWorker(async (worker) => {
         const { packedArray, numSplats, extra } = (await worker.call(
           "unpackPly",
           args,
         )) as {
-          packedArray: Uint32Array;
+          packedArray: [Uint32Array, Uint32Array];
           numSplats: number;
           extra: Record<string, unknown>;
         };
@@ -443,7 +449,7 @@ export async function unpackSplats({
             fileBytes,
           },
         )) as {
-          packedArray: Uint32Array;
+          packedArray: [Uint32Array, Uint32Array];
           numSplats: number;
           extra: Record<string, unknown>;
         };
@@ -457,7 +463,7 @@ export async function unpackSplats({
           {
             fileBytes,
           },
-        )) as { packedArray: Uint32Array; numSplats: number };
+        )) as { packedArray: [Uint32Array, Uint32Array]; numSplats: number };
         return { packedArray, numSplats };
       });
     }
@@ -467,7 +473,7 @@ export async function unpackSplats({
           "decodeKsplat",
           { fileBytes },
         )) as {
-          packedArray: Uint32Array;
+          packedArray: [Uint32Array, Uint32Array];
           numSplats: number;
           extra: Record<string, unknown>;
         };
@@ -480,7 +486,7 @@ export async function unpackSplats({
           "decodePcSogs",
           { fileBytes, extraFiles },
         )) as {
-          packedArray: Uint32Array;
+          packedArray: [Uint32Array, Uint32Array];
           numSplats: number;
           extra: Record<string, unknown>;
         };
@@ -493,7 +499,7 @@ export async function unpackSplats({
           "decodePcSogsZip",
           { fileBytes },
         )) as {
-          packedArray: Uint32Array;
+          packedArray: [Uint32Array, Uint32Array];
           numSplats: number;
           extra: Record<string, unknown>;
         };

--- a/src/SplatMesh.ts
+++ b/src/SplatMesh.ts
@@ -537,7 +537,7 @@ export class SplatMesh extends SplatGenerator {
       near,
       far,
       this.packedSplats.numSplats,
-      this.packedSplats.packedArray,
+      this.packedSplats.packedArray[0], // FIXME
       RAYCAST_ELLIPSOID,
     );
 

--- a/src/antisplat.ts
+++ b/src/antisplat.ts
@@ -66,18 +66,22 @@ export function decodeAntiSplat(
 }
 
 export function unpackAntiSplat(fileBytes: Uint8Array): {
-  packedArray: Uint32Array;
+  packedArray: [Uint32Array, Uint32Array];
   numSplats: number;
 } {
   let numSplats = 0;
   let maxSplats = 0;
-  let packedArray = new Uint32Array(0);
+  const emptyArray = new Uint32Array(0);
+  let packedArray: [Uint32Array, Uint32Array] = [emptyArray, emptyArray];
   decodeAntiSplat(
     fileBytes,
     (cbNumSplats) => {
       numSplats = cbNumSplats;
       maxSplats = computeMaxSplats(numSplats);
-      packedArray = new Uint32Array(maxSplats * 4);
+      packedArray = [
+        new Uint32Array(maxSplats * 4),
+        new Uint32Array(maxSplats * 4),
+      ];
     },
     (
       index,

--- a/src/dyno/output.ts
+++ b/src/dyno/output.ts
@@ -30,13 +30,18 @@ export class OutputPackedSplat
         if (gsplat) {
           return unindentLines(`
             if (isGsplatActive(${gsplat}.flags)) {
-              ${output} = packSplat(${gsplat}.center, ${gsplat}.scales, ${gsplat}.quaternion, ${gsplat}.rgba);
+              uvec4[2] packed = packSplat(${gsplat}.center, ${gsplat}.scales, ${gsplat}.quaternion, ${gsplat}.rgba);
+              ${output} = packed[0];
+              ${output}2 = packed[1];
             } else {
               ${output} = uvec4(0u, 0u, 0u, 0u);
+              ${output}2 = uvec4(0u, 0u, 0u, 0u);
             }
           `);
         }
-        return [`${output} = uvec4(0u, 0u, 0u, 0u);`];
+        return [
+          `${output} = uvec4(0u, 0u, 0u, 0u); ${output}2 = uvec4(0u, 0u, 0u, 0u);`,
+        ];
       },
     });
   }

--- a/src/ksplat.ts
+++ b/src/ksplat.ts
@@ -353,7 +353,7 @@ export function decodeKsplat(
 }
 
 export function unpackKsplat(fileBytes: Uint8Array): {
-  packedArray: Uint32Array;
+  packedArray: [Uint32Array, Uint32Array];
   numSplats: number;
   extra: Record<string, unknown>;
 } {
@@ -387,7 +387,10 @@ export function unpackKsplat(fileBytes: Uint8Array): {
 
   const numSplats = splatCount;
   const maxSplats = computeMaxSplats(numSplats);
-  const packedArray = new Uint32Array(maxSplats * 4);
+  const packedArray: [Uint32Array, Uint32Array] = [
+    new Uint32Array(maxSplats * 4),
+    new Uint32Array(maxSplats * 4),
+  ];
   const extra: Record<string, unknown> = {};
 
   let sectionBase = HEADER_BYTES + maxSectionCount * SECTION_BYTES;

--- a/src/pcsogs.ts
+++ b/src/pcsogs.ts
@@ -15,7 +15,7 @@ export async function unpackPcSogs(
   json: PcSogsJson,
   extraFiles: Record<string, ArrayBuffer>,
 ): Promise<{
-  packedArray: Uint32Array;
+  packedArray: [Uint32Array, Uint32Array];
   numSplats: number;
   extra: Record<string, unknown>;
 }> {
@@ -25,7 +25,10 @@ export async function unpackPcSogs(
 
   const numSplats = json.means.shape[0];
   const maxSplats = computeMaxSplats(numSplats);
-  const packedArray = new Uint32Array(maxSplats * 4);
+  const packedArray: [Uint32Array, Uint32Array] = [
+    new Uint32Array(maxSplats * 4),
+    new Uint32Array(maxSplats * 4),
+  ];
   const extra: Record<string, unknown> = {};
 
   const meansPromise = Promise.all([
@@ -249,7 +252,7 @@ async function decodeImageRgba(fileBytes: ArrayBuffer) {
 }
 
 export async function unpackPcSogsZip(fileBytes: Uint8Array): Promise<{
-  packedArray: Uint32Array;
+  packedArray: [Uint32Array, Uint32Array];
   numSplats: number;
   extra: Record<string, unknown>;
 }> {

--- a/src/shaders/computeUvec4x2.glsl
+++ b/src/shaders/computeUvec4x2.glsl
@@ -1,0 +1,38 @@
+precision highp float;
+precision highp int;
+precision highp sampler2D;
+precision highp usampler2D;
+precision highp isampler2D;
+precision highp sampler2DArray;
+precision highp usampler2DArray;
+precision highp isampler2DArray;
+precision highp sampler3D;
+precision highp usampler3D;
+precision highp isampler3D;
+
+#include <splatDefines>
+
+uniform uint targetLayer;
+uniform int targetBase;
+uniform int targetCount;
+
+layout(location = 0) out uvec4 target;
+layout(location = 1) out uvec4 target2;
+
+{{ GLOBALS }}
+
+void produceSplat(int index) {
+    {{ STATEMENTS }}
+}
+
+void main() {
+    int targetIndex = int(targetLayer << SPLAT_TEX_LAYER_BITS) + int(uint(gl_FragCoord.y) << SPLAT_TEX_WIDTH_BITS) + int(gl_FragCoord.x);
+    int index = targetIndex - targetBase;
+
+    if ((index >= 0) && (index < targetCount)) {
+        produceSplat(index);
+    } else {
+        target = uvec4(0u, 0u, 0u, 0u);
+        target2 = uvec4(0u, 0u, 0u, 0u);
+    }
+}

--- a/src/shaders/splatFragment.glsl
+++ b/src/shaders/splatFragment.glsl
@@ -66,5 +66,5 @@ void main() {
     if (encodeLinear) {
         rgba.rgb = srgbToLinear(rgba.rgb);
     }
-    fragColor = rgba;
+    fragColor = vec4(rgba.rgb * rgba.a, rgba.a);
 }

--- a/src/shaders/splatVertex.glsl
+++ b/src/shaders/splatVertex.glsl
@@ -28,6 +28,7 @@ uniform float clipXY;
 uniform float focalAdjustment;
 
 uniform usampler2DArray packedSplats;
+uniform usampler2DArray packedSplats2;
 
 void main() {
     // Default to outside the frustum so it's discarded if we return early
@@ -46,7 +47,10 @@ void main() {
         (splatIndex >> SPLAT_TEX_WIDTH_BITS) & SPLAT_TEX_HEIGHT_MASK,
         splatIndex >> SPLAT_TEX_LAYER_BITS
     );
-    uvec4 packed = texelFetch(packedSplats, texCoord, 0);
+    uvec4[2] packed = uvec4[2](
+        texelFetch(packedSplats, texCoord, 0),
+        texelFetch(packedSplats2, texCoord, 0)
+    );
 
     vec3 center, scales;
     vec4 quaternion, rgba;

--- a/src/spz.ts
+++ b/src/spz.ts
@@ -6,7 +6,7 @@ import {
   getSplatFileType,
   getSplatFileTypeFromPath,
 } from "./SplatLoader";
-import { GunzipReader, fromHalf, unpackSplat } from "./utils";
+import { GunzipReader, fromHalf } from "./utils";
 
 import { decodeAntiSplat } from "./antisplat";
 import { decodeKsplat } from "./ksplat";


### PR DESCRIPTION
This PR is to explore the possibilities when extending the splat representation from 16 bytes to 32 bytes (2x16) using MRT. Vanilla three.js does not support MRT with 2d texture arrays out-of-the-box, but requires surprisingly few changes (see https://github.com/mrdoob/three.js/pull/30151 and https://github.com/mrxz/three.js/commit/e63a1af54b8a93b500814daae628d85aec4d127b). Hopefully we can get this implemented in Three.js upstream. In this PR I point to a three.js build with the needed changes, so anyone can try it out.

For simplicity the newly available space has only been used to increase the resolution of the center (X, Y, Z) and the colour values, resulting in the following layout:
| Channel | Contents |
|-------------|---------------|
|R1            | `center.x` (32f) |
|G1            | `center.y` (32f) |
|B1            | `center.z` (32f) |
|A1            | `scale.xyz` (3 x 8bit), unchanged from current representation, 8 bit unused |
|R2            | `rgba.r` (16 bit) + `rgba.g` (16 bit) |
|G2            | `rgba.b` (16 bit) + `rgba.a` (16 bit) |
|B2            | `encodeQuatOctXy88R8` (24bit), 8 bit unused |
|A2            | unused|

The main motivation behind was to address the following two prominent issues: 

- float16 quantization issues with splats away from origin (either in source file or moved in scenegraph): https://github.com/sparkjsdev/spark/issues/104, https://github.com/sparkjsdev/spark/issues/36#issuecomment-3074858674
- "dimmer" results due to clamping of colour channels: https://github.com/sparkjsdev/spark/issues/81, https://github.com/sparkjsdev/spark/issues/36#issuecomment-3074618885

Of course, there's plenty of unused bits, so the scales and rotation can be encoded with higher precision as well. For the colour channels I've opted for encoding them as 0-65535 converted to 0.0-257.0 in the shader. This is overkill, but can at least represent the values > 1.0, which with pre-multiplied alpha (also in this PR) brings back the brighter highlights. Ideally we pick a better representation that closely matches the possible input values, which might even be negative. (Though it's unclear to me if negative colour channel values contribute meaningfully to a splat model)

The biggest drawback is of course that memory consumption is doubled. And the impact on performance will have to be assessed properly. Since I only have a reliable profiling setup for the Quest 3 at the moment, I've measured the app time (CPU + GPU) for the webxr example in the repo. It increased slightly from 15.534ms (before) to 15.614ms (after).

Not surprising as the GPU metrics never indicated texture fetching to be the bottleneck on the Quest 3. So having to perform more texture fetches per vertex shader execution doesn't seem to be a problem. Though no idea if this generalizes to other TBDR GPUs.

To make the texture uploading easier, I've opted for representing the `packedArray` as two arrays, one for each texture. This is somewhat awkward representation (especially for the loaders). The alternative would be to tightly pack the splats in one array (as is currently the case) and split them into two when uploading to the GPU, which isn't ideal either... 