### PR TITLE
Implement float32 sorting option

### DIFF
--- a/docs/docs/spark-viewpoint.md
+++ b/docs/docs/spark-viewpoint.md
@@ -23,6 +23,7 @@ const viewpoint = spark.newViewpoint({
   sortCoorient?: boolean;
   depthBias?: number;
   sort360?: boolean;
+  sort32?: boolean;
 });
 ```
 
@@ -44,6 +45,7 @@ const viewpoint = spark.newViewpoint({
 | **sortCoorient**  | View direction dot product threshold for re-sorting splats. For `sortRadial: true` it defaults to 0.99 while `sortRadial: false` uses 0.999 because it is more sensitive to view direction. (default: `0.99` if `sortRadial` else `0.999`)
 | **depthBias**     | Constant added to Z-depth to bias values into the positive range for `sortRadial: false`, but also used for culling splats "well behind" the viewpoint origin (default: `1.0`)
 | **sort360**       | Set this to true if rendering a 360 to disable "behind the viewpoint" culling during sorting. This is set automatically when rendering 360 envMaps using the `SparkRenderer.renderEnvMap()` utility function. (default: `false`)
+| **sort32**        | Set this to true to sort with float32 precision with two-pass sort. (default: `false`)
 
 ## `dispose()`
 

--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -480,6 +480,8 @@
       stats.dom.style.display = value ? "block" : "none";
     });
     gui.add(spark.defaultView, "sortRadial").name("Radial sort").listen();
+    spark.defaultView.sort32 = true;
+    gui.add(spark.defaultView, "sort32").name("Float32 sort").listen();
     gui.add(grid, "opacity", 0, 1, 0.01).name("Grid opacity").listen();
     gui.add({
       logFocalDistance: 0.0,

--- a/rust/spark-internal-rs/src/sort.rs
+++ b/rust/spark-internal-rs/src/sort.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 
-const DEPTH_INFINITY: u32 = 0x7c00;
-const DEPTH_SIZE: usize = DEPTH_INFINITY as usize + 1;
+const DEPTH_INFINITY_F16: u32 = 0x7c00;
+const DEPTH_SIZE_F16: usize = DEPTH_INFINITY_F16 as usize + 1;
 
 #[derive(Default)]
 pub struct SortBuffers {
@@ -18,8 +18,8 @@ impl SortBuffers {
         if self.ordering.len() < max_splats {
             self.ordering.resize(max_splats, 0);
         }
-        if self.buckets.len() < DEPTH_SIZE {
-            self.buckets.resize(DEPTH_SIZE, 0);
+        if self.buckets.len() < DEPTH_SIZE_F16 {
+            self.buckets.resize(DEPTH_SIZE_F16, 0);
         }
     }
 }
@@ -30,11 +30,11 @@ pub fn sort_internal(buffers: &mut SortBuffers, num_splats: usize) -> anyhow::Re
 
     // Set the bucket counts to zero
     buckets.clear();
-    buckets.resize(DEPTH_SIZE, 0);
+    buckets.resize(DEPTH_SIZE_F16, 0);
 
     // Count the number of splats in each bucket
     for &metric in readback.iter() {
-        if (metric as u32) < DEPTH_INFINITY {
+        if (metric as u32) < DEPTH_INFINITY_F16 {
             buckets[metric as usize] += 1;
         }
     }
@@ -49,7 +49,7 @@ pub fn sort_internal(buffers: &mut SortBuffers, num_splats: usize) -> anyhow::Re
 
     // Write out splat indices at the right location using bucket offsets
     for (index, &metric) in readback.iter().enumerate() {
-        if (metric as u32) < DEPTH_INFINITY {
+        if (metric as u32) < DEPTH_INFINITY_F16 {
             ordering[buckets[metric as usize] as usize] = index as u32;
             buckets[metric as usize] += 1;
         }
@@ -63,5 +63,113 @@ pub fn sort_internal(buffers: &mut SortBuffers, num_splats: usize) -> anyhow::Re
             buckets[0]
         ));
     }
+    Ok(active_splats)
+}
+
+const DEPTH_INFINITY_F32: u32 = 0x7f800000;
+const RADIX_BASE: usize    = 1 << 16; // 65536
+
+#[derive(Default)]
+pub struct Sort32Buffers {
+    /// raw f32 bit‑patterns (one per splat)
+    pub readback: Vec<u32>,
+    /// output indices
+    pub ordering: Vec<u32>,
+    /// bucket counts / offsets (length == RADIX_BASE)
+    pub buckets16: Vec<u32>,
+    /// scratch space for indices
+    pub scratch: Vec<u32>,
+}
+
+impl Sort32Buffers {
+    /// ensure all internal buffers are large enough for up to `max_splats`
+    pub fn ensure_size(&mut self, max_splats: usize) {
+        if self.readback.len() < max_splats {
+            self.readback.resize(max_splats, 0);
+        }
+        if self.ordering.len() < max_splats {
+            self.ordering.resize(max_splats, 0);
+        }
+        if self.scratch.len() < max_splats {
+            self.scratch.resize(max_splats, 0);
+        }
+        if self.buckets16.len() < RADIX_BASE {
+            self.buckets16.resize(RADIX_BASE, 0);
+        }
+    }
+}
+
+/// Two‑pass radix sort (base 2¹⁶) of 32‑bit float bit‑patterns,
+/// descending order (largest keys first). Mirrors the JS `sort32Splats`.
+pub fn sort32_internal(
+    buffers: &mut Sort32Buffers,
+    max_splats: usize,
+    num_splats: usize,
+) -> anyhow::Result<u32> {
+    // make sure our buffers can hold `max_splats`
+    buffers.ensure_size(max_splats);
+
+    let Sort32Buffers { readback, ordering, buckets16, scratch } = buffers;
+    let keys = &readback[..num_splats];
+
+    // ——— Pass #1: bucket by inv(low 16 bits) ———
+    buckets16.fill(0);
+    for &key in keys.iter() {
+        if key < DEPTH_INFINITY_F32 {
+            let inv = !key;
+            buckets16[(inv & 0xFFFF) as usize] += 1;
+        }
+    }
+    // exclusive prefix‑sum → starting offsets
+    let mut total: u32 = 0;
+    for slot in buckets16.iter_mut() {
+        let cnt = *slot;
+        *slot = total;
+        total = total.wrapping_add(cnt);
+    }
+    let active_splats = total;
+
+    // scatter into scratch by low bits of inv
+    for (i, &key) in keys.iter().enumerate() {
+        if key < DEPTH_INFINITY_F32 {
+            let inv = !key;
+            let lo = (inv & 0xFFFF) as usize;
+            scratch[buckets16[lo] as usize] = i as u32;
+            buckets16[lo] += 1;
+        }
+    }
+
+    // ——— Pass #2: bucket by inv(high 16 bits) ———
+    buckets16.fill(0);
+    for &idx in scratch.iter().take(active_splats as usize) {
+        let key = keys[idx as usize];
+        let inv = !key;
+        buckets16[(inv >> 16) as usize] += 1;
+    }
+    // exclusive prefix‑sum again
+    let mut sum: u32 = 0;
+    for slot in buckets16.iter_mut() {
+        let cnt = *slot;
+        *slot = sum;
+        sum = sum.wrapping_add(cnt);
+    }
+    // scatter into final ordering by high bits of inv
+    for &idx in scratch.iter().take(active_splats as usize) {
+        let key = keys[idx as usize];
+        let inv = !key;
+        let hi = (inv >> 16) as usize;
+        ordering[buckets16[hi] as usize] = idx;
+        buckets16[hi] += 1;
+    }
+
+    // sanity‑check: last bucket should have consumed all entries
+    if buckets16[RADIX_BASE - 1] != active_splats {
+        return Err(anyhow!(
+            "Expected {} active splats but got {}",
+            active_splats,
+            buckets16[RADIX_BASE - 1]
+        ));
+    }
+
     Ok(active_splats)
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,4 +1,4 @@
-import init_wasm, { sort_splats } from "spark-internal-rs";
+import init_wasm, { sort_splats, sort32_splats } from "spark-internal-rs";
 import type { PcSogsJson, TranscodeSpzInput } from "./SplatLoader";
 import { unpackAntiSplat } from "./antisplat";
 import { WASM_SPLAT_SORT } from "./defines";
@@ -18,6 +18,7 @@ import {
   setPackedSplatQuat,
   setPackedSplatRgb,
   setPackedSplatScales,
+  toHalf,
 } from "./utils";
 
 // WebWorker for Spark's background CPU tasks, such as Gsplat file decoding
@@ -134,8 +135,6 @@ async function onMessage(event: MessageEvent) {
           readback: Uint16Array;
           ordering: Uint32Array;
         };
-        // Benchmark sort
-        // benchmarkSort(numSplats, readback, ordering);
         if (WASM_SPLAT_SORT) {
           result = {
             id,
@@ -148,6 +147,31 @@ async function onMessage(event: MessageEvent) {
             id,
             readback,
             ...sortDoubleSplats({ numSplats, readback, ordering }),
+          };
+        }
+        break;
+      }
+      case "sort32Splats": {
+        const { maxSplats, numSplats, readback, ordering } = args as {
+          maxSplats: number;
+          numSplats: number;
+          readback: Uint32Array;
+          ordering: Uint32Array;
+        };
+        // Benchmark sort
+        // benchmarkSort(numSplats, readback, ordering);
+        if (WASM_SPLAT_SORT) {
+          result = {
+            id,
+            readback,
+            ordering,
+            activeSplats: sort32_splats(numSplats, readback, ordering),
+          };
+        } else {
+          result = {
+            id,
+            readback,
+            ...sort32Splats({ maxSplats, numSplats, readback, ordering }),
           };
         }
         break;
@@ -168,6 +192,7 @@ async function onMessage(event: MessageEvent) {
     }
   } catch (e) {
     error = e;
+    console.error(error);
   }
 
   // Send the result or error back to the main thread, making sure to transfer any ArrayBuffers
@@ -179,14 +204,32 @@ async function onMessage(event: MessageEvent) {
 
 function benchmarkSort(
   numSplats: number,
-  readback: Uint16Array,
+  readback32: Uint32Array,
   ordering: Uint32Array,
 ) {
   if (numSplats > 0) {
+    console.log("Running sort benchmark");
+    const readbackF32 = new Float32Array(readback32.buffer);
+    const readback16 = new Uint16Array(readback32.length);
+    for (let i = 0; i < numSplats; ++i) {
+      readback16[i] = toHalf(readbackF32[i]);
+    }
+
     const WARMUP = 10;
     for (let i = 0; i < WARMUP; ++i) {
-      const activeSplats = sort_splats(numSplats, readback, ordering);
-      const results = sortDoubleSplats({ numSplats, readback, ordering });
+      const activeSplats = sort_splats(numSplats, readback16, ordering);
+      const activeSplats32 = sort32_splats(numSplats, readback32, ordering);
+      const results = sortDoubleSplats({
+        numSplats,
+        readback: readback16,
+        ordering,
+      });
+      const results32 = sort32Splats({
+        maxSplats: numSplats,
+        numSplats,
+        readback: readback32,
+        ordering,
+      });
     }
 
     const TIMING_SAMPLES = 1000;
@@ -194,18 +237,43 @@ function benchmarkSort(
 
     start = performance.now();
     for (let i = 0; i < TIMING_SAMPLES; ++i) {
-      const activeSplats = sort_splats(numSplats, readback, ordering);
+      const activeSplats = sort_splats(numSplats, readback16, ordering);
     }
     const wasmTime = (performance.now() - start) / TIMING_SAMPLES;
 
     start = performance.now();
     for (let i = 0; i < TIMING_SAMPLES; ++i) {
-      const results = sortDoubleSplats({ numSplats, readback, ordering });
+      const results = sortDoubleSplats({
+        numSplats,
+        readback: readback16,
+        ordering,
+      });
     }
     const jsTime = (performance.now() - start) / TIMING_SAMPLES;
 
     console.log(
       `JS: ${jsTime} ms, WASM: ${wasmTime} ms, numSplats: ${numSplats}`,
+    );
+
+    start = performance.now();
+    for (let i = 0; i < TIMING_SAMPLES; ++i) {
+      const activeSplats32 = sort32_splats(numSplats, readback32, ordering);
+    }
+    const wasm32Time = (performance.now() - start) / TIMING_SAMPLES;
+
+    start = performance.now();
+    for (let i = 0; i < TIMING_SAMPLES; ++i) {
+      const results = sort32Splats({
+        maxSplats: numSplats,
+        numSplats,
+        readback: readback32,
+        ordering,
+      });
+    }
+    const js32Time = (performance.now() - start) / TIMING_SAMPLES;
+
+    console.log(
+      `JS32: ${js32Time} ms, WASM32: ${wasm32Time} ms, numSplats: ${numSplats}`,
     );
   }
 }
@@ -338,9 +406,9 @@ function unpackSpz(fileBytes: Uint8Array): {
 }
 
 // Array of buckets for sorting float16 distances with range [0, DEPTH_INFINITY].
-const DEPTH_INFINITY = 0x7c00;
-const DEPTH_SIZE = DEPTH_INFINITY + 1;
-let depthArray: Uint32Array | null = null;
+const DEPTH_INFINITY_F16 = 0x7c00;
+const DEPTH_SIZE_16 = DEPTH_INFINITY_F16 + 1;
+let depthArray16: Uint32Array | null = null;
 
 function sortSplats({
   totalSplats,
@@ -353,10 +421,10 @@ function sortSplats({
   // Sort totalSplats Gsplats, each with 4 bytes of readback, and outputs Uint32Array
   // of indices from most distant to nearest. Each 4 bytes encode a float16 distance
   // and unused high bytes.
-  if (!depthArray) {
-    depthArray = new Uint32Array(DEPTH_SIZE);
+  if (!depthArray16) {
+    depthArray16 = new Uint32Array(DEPTH_SIZE_16);
   }
-  depthArray.fill(0);
+  depthArray16.fill(0);
 
   const readbackUint32 = readback.map((layer) => new Uint32Array(layer.buffer));
   const layerSize = readbackUint32[0].length;
@@ -368,17 +436,17 @@ function sortSplats({
     const layerSplats = Math.min(readbackLayer.length, totalSplats - layerBase);
     for (let i = 0; i < layerSplats; ++i) {
       const pri = readbackLayer[i] & 0x7fff;
-      if (pri < DEPTH_INFINITY) {
-        depthArray[pri] += 1;
+      if (pri < DEPTH_INFINITY_F16) {
+        depthArray16[pri] += 1;
       }
     }
     layerBase += layerSplats;
   }
 
   let activeSplats = 0;
-  for (let j = 0; j < DEPTH_SIZE; ++j) {
-    const nextIndex = activeSplats + depthArray[j];
-    depthArray[j] = activeSplats;
+  for (let j = 0; j < DEPTH_SIZE_16; ++j) {
+    const nextIndex = activeSplats + depthArray16[j];
+    depthArray16[j] = activeSplats;
     activeSplats = nextIndex;
   }
 
@@ -388,16 +456,16 @@ function sortSplats({
     const layerSplats = Math.min(readbackLayer.length, totalSplats - layerBase);
     for (let i = 0; i < layerSplats; ++i) {
       const pri = readbackLayer[i] & 0x7fff;
-      if (pri < DEPTH_INFINITY) {
-        ordering[depthArray[pri]] = layerBase + i;
-        depthArray[pri] += 1;
+      if (pri < DEPTH_INFINITY_F16) {
+        ordering[depthArray16[pri]] = layerBase + i;
+        depthArray16[pri] += 1;
       }
     }
     layerBase += layerSplats;
   }
-  if (depthArray[DEPTH_SIZE - 1] !== activeSplats) {
+  if (depthArray16[DEPTH_SIZE_16 - 1] !== activeSplats) {
     throw new Error(
-      `Expected ${activeSplats} active splats but got ${depthArray[DEPTH_SIZE - 1]}`,
+      `Expected ${activeSplats} active splats but got ${depthArray16[DEPTH_SIZE_16 - 1]}`,
     );
   }
 
@@ -415,16 +483,16 @@ function sortDoubleSplats({
   ordering: Uint32Array;
 } {
   // Ensure depthArray is allocated and zeroed out for our buckets.
-  if (!depthArray) {
-    depthArray = new Uint32Array(DEPTH_SIZE);
+  if (!depthArray16) {
+    depthArray16 = new Uint32Array(DEPTH_SIZE_16);
   }
-  depthArray.fill(0);
+  depthArray16.fill(0);
 
   // Count the number of splats in each bucket (cull Gsplats at infinity).
   for (let i = 0; i < numSplats; ++i) {
     const pri = readback[i];
-    if (pri < DEPTH_INFINITY) {
-      depthArray[pri] += 1;
+    if (pri < DEPTH_INFINITY_F16) {
+      depthArray16[pri] += 1;
     }
   }
 
@@ -432,9 +500,9 @@ function sortDoubleSplats({
   // total number of active (non-infinity) splats, going in reverse order
   // because we want most distant Gsplats to be first in the output array.
   let activeSplats = 0;
-  for (let j = DEPTH_INFINITY - 1; j >= 0; --j) {
-    const nextIndex = activeSplats + depthArray[j];
-    depthArray[j] = activeSplats;
+  for (let j = DEPTH_INFINITY_F16 - 1; j >= 0; --j) {
+    const nextIndex = activeSplats + depthArray16[j];
+    depthArray16[j] = activeSplats;
     activeSplats = nextIndex;
   }
 
@@ -442,16 +510,106 @@ function sortDoubleSplats({
   // bucket order.
   for (let i = 0; i < numSplats; ++i) {
     const pri = readback[i];
-    if (pri < DEPTH_INFINITY) {
-      ordering[depthArray[pri]] = i;
-      depthArray[pri] += 1;
+    if (pri < DEPTH_INFINITY_F16) {
+      ordering[depthArray16[pri]] = i;
+      depthArray16[pri] += 1;
     }
   }
   // Sanity check that the end of the closest bucket is the same as
   // our total count of active splats (not at infinity).
-  if (depthArray[0] !== activeSplats) {
+  if (depthArray16[0] !== activeSplats) {
     throw new Error(
-      `Expected ${activeSplats} active splats but got ${depthArray[0]}`,
+      `Expected ${activeSplats} active splats but got ${depthArray16[0]}`,
+    );
+  }
+
+  return { activeSplats, ordering };
+}
+
+const DEPTH_INFINITY_F32 = 0x7f800000;
+let bucket16: Uint32Array | null = null;
+let scratchSplats: Uint32Array | null = null;
+
+// two-pass radix sort (base 65536) of 32-bit keys in readback,
+// but placing largest values first.
+function sort32Splats({
+  maxSplats,
+  numSplats,
+  readback, // Uint32Array of bit‑patterns
+  ordering, // Uint32Array to fill with sorted indices
+}: {
+  maxSplats: number;
+  numSplats: number;
+  readback: Uint32Array;
+  ordering: Uint32Array;
+}): { activeSplats: number; ordering: Uint32Array } {
+  const BASE = 1 << 16; // 65536
+
+  // allocate once
+  if (!bucket16) {
+    bucket16 = new Uint32Array(BASE);
+  }
+  if (!scratchSplats || scratchSplats.length < maxSplats) {
+    scratchSplats = new Uint32Array(maxSplats);
+  }
+
+  //
+  // ——— Pass #1: bucket by inv(lo 16 bits) ———
+  //
+  bucket16.fill(0);
+  for (let i = 0; i < numSplats; ++i) {
+    const key = readback[i];
+    if (key < DEPTH_INFINITY_F32) {
+      const inv = ~key >>> 0;
+      bucket16[inv & 0xffff] += 1;
+    }
+  }
+  // exclusive prefix‑sum → starting offsets
+  let total = 0;
+  for (let b = 0; b < BASE; ++b) {
+    const c = bucket16[b];
+    bucket16[b] = total;
+    total += c;
+  }
+  const activeSplats = total;
+
+  // scatter into scratch by low bits of inv
+  for (let i = 0; i < numSplats; ++i) {
+    const key = readback[i];
+    if (key < DEPTH_INFINITY_F32) {
+      const inv = ~key >>> 0;
+      scratchSplats[bucket16[inv & 0xffff]++] = i;
+    }
+  }
+
+  //
+  // ——— Pass #2: bucket by inv(hi 16 bits) ———
+  //
+  bucket16.fill(0);
+  for (let k = 0; k < activeSplats; ++k) {
+    const idx = scratchSplats[k];
+    const inv = ~readback[idx] >>> 0;
+    bucket16[inv >>> 16] += 1;
+  }
+  // exclusive prefix‑sum again
+  let sum = 0;
+  for (let b = 0; b < BASE; ++b) {
+    const c = bucket16[b];
+    bucket16[b] = sum;
+    sum += c;
+  }
+
+  // scatter into final ordering by high bits of inv
+  for (let k = 0; k < activeSplats; ++k) {
+    const idx = scratchSplats[k];
+    const inv = ~readback[idx] >>> 0;
+    ordering[bucket16[inv >>> 16]++] = idx;
+  }
+
+  // sanity‑check: the last bucket should have eaten all entries
+  if (bucket16[BASE - 1] !== activeSplats) {
+    throw new Error(
+      `Expected ${activeSplats} active splats but got ${bucket16[BASE - 1]}`,
     );
   }
 


### PR DESCRIPTION
This PR adds an option `sort32` to `SparkViewpoint` to enable float32 sorting precision, implemented via 2-pass radix sort (base 65536) on CPU worker. Each SparkViewpoint can choose for itself whether to use float32 precision or the default float16 mode, so you could have a "faster" viewpoint for real-time display, and a "more accurate" viewpoint that's doing a video render-out using higher precision.

The below video shows an example of improvement possible with this, albeit with settings designed to "exaggerate" high-contrast changes with non-AA and low-DPI:

https://github.com/user-attachments/assets/09171e6f-d28e-4b34-bbac-ed61450361c4

Benchmarks show the new float32 sort is 2.5-3x slower than float16 sort, so giving the user an option gives us the best of both worlds: high-precision for users that care, higher performance if you don't care:

| Browser | JS16 (ms) | Wasm16 | JS32 | Wasm32 |
|---|---|---|---|---|
| Safari | 1.704 | 1.430 | 4.677 | 3.934 |
| Chrome | 3.242 | 1.411 | 7.189 | 3.808 |
| Firefox | 1.563 | 1.558 | 5.502 | 4.283 |

Added option to examples/editor to select the mode, default to float32 on.