### PR TITLE
Use `material.premultipliedAlpha` to adjust blending function

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -294,14 +294,8 @@ export class SparkRenderer extends THREE.Mesh {
       vertexShader: shaders.splatVertex,
       fragmentShader: shaders.splatFragment,
       uniforms,
+      premultipliedAlpha,
       transparent: true,
-      blending: premultipliedAlpha
-        ? THREE.CustomBlending
-        : THREE.NormalBlending,
-      blendSrc: premultipliedAlpha ? THREE.OneFactor : THREE.SrcAlphaFactor,
-      blendDst: premultipliedAlpha
-        ? THREE.OneMinusSrcAlphaFactor
-        : THREE.OneFactor,
       depthTest: true,
       depthWrite: false,
       side: THREE.DoubleSide,
@@ -435,8 +429,6 @@ export class SparkRenderer extends THREE.Mesh {
       time: { value: 0 },
       // Delta time in seconds since last frame
       deltaTime: { value: 0 },
-      // Whether to use premultiplied alpha when accumulating splat RGB
-      premultipliedAlpha: { value: true },
       // Whether to encode Gsplat with linear RGB (for environment mapping)
       encodeLinear: { value: false },
       // Debug flag that alternates each frame
@@ -531,20 +523,10 @@ export class SparkRenderer extends THREE.Mesh {
 
     if (isNewFrame) {
       // Keep these uniforms the same for both eyes if in WebXR
-      const blending = this.premultipliedAlpha
-        ? THREE.CustomBlending
-        : THREE.NormalBlending;
-      if (blending !== this.material.blending) {
-        this.material.blending = blending;
-        this.material.blendSrc = this.premultipliedAlpha
-          ? THREE.OneFactor
-          : THREE.SrcAlphaFactor;
-        this.material.blendDst = this.premultipliedAlpha
-          ? THREE.OneMinusSrcAlphaFactor
-          : THREE.OneFactor;
+      if (this.material.premultipliedAlpha !== this.premultipliedAlpha) {
+        this.material.premultipliedAlpha = this.premultipliedAlpha;
         this.material.needsUpdate = true;
       }
-      this.uniforms.premultipliedAlpha.value = this.premultipliedAlpha;
       this.uniforms.time.value = time;
       this.uniforms.deltaTime.value = deltaTime;
       // Alternating debug flag that can aid in visual debugging

--- a/src/shaders/splatFragment.glsl
+++ b/src/shaders/splatFragment.glsl
@@ -6,7 +6,6 @@ precision highp int;
 
 uniform float near;
 uniform float far;
-uniform bool premultipliedAlpha;
 uniform bool encodeLinear;
 uniform float maxStdDev;
 uniform float minAlpha;
@@ -69,9 +68,9 @@ void main() {
         rgba.rgb = srgbToLinear(rgba.rgb);
     }
     
-    if (premultipliedAlpha) {
+    #ifdef PREMULTIPLIED_ALPHA
         fragColor = vec4(rgba.rgb * rgba.a, rgba.a);
-    } else {
+    #else
         fragColor = rgba;
-    }
+    #endif
 }


### PR DESCRIPTION
With #134 the default blending now uses `premultipliedAlpha`. The material system of Three.js has built-in support for this, which takes care of setting the right blending function as well as providing a define in the fragment shader.

This PR replaces the custom blending function and instead uses the `premultipliedAlpha` setup. Additionally the uniform has been replaced with the define. This does mean that changing the flag requires a shader recompilation, though these variants are cached by Three.js. In the unlikely situation that a user repeatedly switches this flag, it should only incur a recompilation once.