### PR TITLE
Use child mesh in `SplatMesh` to auto-inject `SparkRenderer` instead of monkey-patching

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -79,6 +79,7 @@
     const canvas = document.getElementById("canvas");
     const renderer = new THREE.WebGLRenderer({ canvas });
     const spark = new SparkRenderer({ renderer });
+    scene.add(spark);
 
     function handleResize() {
       const width = canvas.clientWidth;

--- a/examples/envmap/index.html
+++ b/examples/envmap/index.html
@@ -54,6 +54,7 @@
 
     // Explicitly create a SparkRenderer to render environment maps
     const spark = new SparkRenderer({ renderer });
+    scene.add(spark);
 
     const splatURL = await getAssetFileURL("fireplace.spz");
     const packedSplats = new PackedSplats({ url: splatURL });

--- a/examples/multiple-viewpoints/index.html
+++ b/examples/multiple-viewpoints/index.html
@@ -40,6 +40,7 @@
 
     // Explicitly create a SparkRenderer in the scene to spawn new viewpoints
     const spark = new SparkRenderer({ renderer });
+    scene.add(spark);
 
     const splatURL = await getAssetFileURL("butterfly.spz");
     const butterfly = new SplatMesh({ url: splatURL });

--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -40,48 +40,6 @@ import {
 // of 5 to avoid excessive memory usage.
 const MAX_ACCUMULATORS = 5;
 
-// Scene.onBeforeRender monkey-patch to
-// inject a SparkRenderer into a scene with SplatMeshes if there isn't
-// one already. Restore original Scene.onBeforeRenderer and Scene.add when done.
-let hasSplatMesh = false;
-let hasSparkRenderer = false;
-
-let sparkRendererInstance: SparkRenderer;
-
-function containsSplatMesh(object3D: THREE.Object3D) {
-  let hasSplatMesh = false;
-  if (object3D instanceof SplatMesh) {
-    return true;
-  }
-  object3D.traverse((child: THREE.Object3D) => {
-    hasSplatMesh = hasSplatMesh || child instanceof SplatMesh;
-  });
-  return hasSplatMesh;
-}
-
-const sceneAdd = THREE.Scene.prototype.add;
-THREE.Scene.prototype.add = function (object: THREE.Object3D) {
-  hasSplatMesh = hasSplatMesh || containsSplatMesh(object);
-  hasSparkRenderer = hasSparkRenderer || object instanceof SparkRenderer;
-  sceneAdd.call(this, object);
-  return this;
-};
-
-const sceneOnBeforeRender = THREE.Scene.prototype.onBeforeRender;
-THREE.Scene.prototype.onBeforeRender = function (
-  renderer: THREE.WebGLRenderer,
-) {
-  if (!hasSplatMesh) {
-    return;
-  }
-  if (!hasSparkRenderer) {
-    const spark = sparkRendererInstance || new SparkRenderer({ renderer });
-    this.add(spark);
-  }
-  THREE.Scene.prototype.onBeforeRender = sceneOnBeforeRender;
-  THREE.Scene.prototype.add = sceneAdd;
-};
-
 export type SparkRendererOptions = {
   /**
    * Pass in your THREE.WebGLRenderer instance so Spark can perform work
@@ -367,8 +325,6 @@ export class SparkRenderer extends THREE.Mesh {
     this.prepareViewpoint(this.viewpoint);
 
     this.clock = options.clock ? cloneClock(options.clock) : new THREE.Clock();
-
-    sparkRendererInstance = this;
   }
 
   static makeUniforms() {


### PR DESCRIPTION
The current monkey-patching of `THREE.Scene` to auto-inject a `SparkRenderer` has many limitations and can easily break. The following setups cause issues that aren't immediately clear to the user:

- More than one `THREE.Scene` (https://github.com/sparkjsdev/spark/issues/78#issuecomment-3151948004)
- Using more than one canvas (#98, #107)
- Adding a `SparkRenderer` or `SplatMesh` using [`.attach()`](https://threejs.org/docs/#api/en/core/Object3D.attach) instead of [`.add()`](https://threejs.org/docs/#api/en/core/Object3D.add)
- Adding a `SplatMesh` as an indirect descendant of the scene, if one of the ancestors has already been added to the scene.
- Adding a `SparkRenderer` as an indirect descendant of the scene
- Using a custom `scene.onBeforeRenderer`

This PR introduces an alternative approach. Each `SplatMesh` adds an empty mesh to itself. During rendering it checks if the scene contains a `SparkRenderer` and if not injects one. Regardless of the outcome it will remove itself, ensuring the check is a one-time cost per `SplatMesh`.

This does mean that the following pattern is no longer allowed:
```js
const spark = new SparkRenderer({ renderer });
// Never add it to the scene ourselves, yet expect it to take effect
```
Though, personally I think that's for the better. A few examples used this pattern, though it's unclear to me if this was intentional or not.