### PR TITLE
Avoid allocating THREE.Quaternion instances in `setPackedSplat`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -370,7 +370,7 @@ export function setPackedSplat(
 
   // Alternate internal encodings commented out below.
   const uQuat = encodeQuatOctXy88R8(
-    new THREE.Quaternion(quatX, quatY, quatZ, quatW),
+    tempQuaternion.set(quatX, quatY, quatZ, quatW),
   );
   // const uQuat = encodeQuatXyz888(new THREE.Quaternion(quatX, quatY, quatZ, quatW));
   // const uQuat = encodeQuatEulerXyz888(new THREE.Quaternion(quatX, quatY, quatZ, quatW));


### PR DESCRIPTION
Follow-up for https://github.com/sparkjsdev/spark/pull/147.

The `setPackedSplat` function still instantiated a new `THREE.Quaternion` each time. The above PR did update it for `setPackedSplatQuat`, but missed this instance.