### PR TITLE
Restore multi-object add support for THREE.Scene.add (#162)

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -60,10 +60,12 @@ function containsSplatMesh(object3D: THREE.Object3D) {
 }
 
 const sceneAdd = THREE.Scene.prototype.add;
-THREE.Scene.prototype.add = function (object: THREE.Object3D) {
-  hasSplatMesh = hasSplatMesh || containsSplatMesh(object);
-  hasSparkRenderer = hasSparkRenderer || object instanceof SparkRenderer;
-  sceneAdd.call(this, object);
+THREE.Scene.prototype.add = function (...objects: THREE.Object3D[]) {
+  for (const object of objects) {
+    hasSplatMesh = hasSplatMesh || containsSplatMesh(object);
+    hasSparkRenderer = hasSparkRenderer || object instanceof SparkRenderer;
+    sceneAdd.call(this, object);
+  }
   return this;
 };
 


### PR DESCRIPTION
Updates the Scene.add override to handle multiple objects in a single call to preserve original three.js behavior. Uses rest parameters to capture all arguments and applies checks for each object.

Fixes #162 