### PR TITLE
Add SPZ v3, smallest 3 quaternion encoding support

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,12 @@ const f16buffer = supportsFloat16Array
   : null;
 const u16buffer = new Uint16Array(f16buffer?.buffer);
 
+// Returns a normalized array of numbers
+export function normalize(vec: number[]) {
+  const norm = Math.sqrt(vec.reduce((acc, v) => acc + v * v, 0));
+  return vec.map((v) => v / norm);
+}
+
 // Reinterpret the bits of a float32 as a uint32
 export function floatBitsToUint(f: number): number {
   f32buffer[0] = f;


### PR DESCRIPTION
This addresses https://github.com/sparkjsdev/spark/issues/151 

SPZ v3 has been released with support for smallest 3 quaternion encoding and decoding. The relevant changes are [here](https://github.com/nianticlabs/spz/commit/526e51600e6af69079df2051ac324648695ca02b)

This implements support for the latest version of SPZ, and maintains backwards compatibility for reading v2 spz files.

A visual comparison for the [mipnerf360 bicycle scene](https://jonbarron.info/mipnerf360/) between v2 and v3 is below.

<img width="1351" height="943" alt="image" src="https://github.com/user-attachments/assets/9e22a867-1b94-415a-a440-b4cf438cd41b" />

<img width="1351" height="943" alt="image" src="https://github.com/user-attachments/assets/0573bfd7-9f00-47f9-863d-a4c62044163e" />




