### PR TITLE
Add missing 'Splat Reveal Effects' example

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -437,7 +437,8 @@
           <a href="#dynamic-lighting" data-example="dynamic-lighting" class="example-link">Dynamic Lighting</a>
           <a href="#particle-animation" data-example="particle-animation" class="example-link">Particle Animation</a>
           <a href="#particle-simulation" data-example="particle-simulation" class="example-link">Particle Simulation</a>
-          <a href="#splat-painter" data-example="splat-painter" class="example-link">Splat Reveal Effects</a>
+          <a href="#splat-painter" data-example="splat-painter" class="example-link">Splat Painter</a>
+          <a href="#splat-reveal-effects" data-example="splat-reveal-effects" class="example-link">Splat Reveal Effects</a>
           <a href="#splat-shader-effects" data-example="splat-shader-effects" class="example-link">Splat Shader Effects</a>
           <a href="#splat-transitions" data-example="splat-transitions" class="example-link">Splat Transitions</a>
           <a href="#stochastic" data-example="stochastic" class="example-link">Stochastic splat sorting</a>


### PR DESCRIPTION
When looking at the hosted examples page (https://sparkjs.dev/examples/), the `Splat Reveal Effects` link loads the `Splat Painter` example instead. The actual `Splat Reveal Effects` example appears to be missing. It seems that when `Splat Painter` was added it incorrectly got the `Splat Reveal Effects` name after which the original `Splat Reveal Effects` got removed (2ec7d706a11df26c0afdfc7227de0953d53e7387).

This PR re-introduces the link to the `Splat Reveal Effects` example and fixes the naming for the the `Splat Painter` example.