### PR TITLE
Use DecompressionStream for decompressing .spz files

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -61,7 +61,7 @@ async function onMessage(event: MessageEvent) {
           fileBytes: Uint8Array;
           splatEncoding: SplatEncoding;
         };
-        const decoded = unpackSpz(fileBytes, splatEncoding);
+        const decoded = await unpackSpz(fileBytes, splatEncoding);
         result = {
           id,
           numSplats: decoded.numSplats,
@@ -379,21 +379,22 @@ async function unpackPly({
   return { packedArray, numSplats, extra };
 }
 
-function unpackSpz(
+async function unpackSpz(
   fileBytes: Uint8Array,
   splatEncoding: SplatEncoding,
-): {
+): Promise<{
   packedArray: Uint32Array;
   numSplats: number;
   extra: Record<string, unknown>;
-} {
+}> {
   const spz = new SpzReader({ fileBytes });
+  await spz.parseHeader();
   const numSplats = spz.numSplats;
   const maxSplats = computeMaxSplats(numSplats);
   const packedArray = new Uint32Array(maxSplats * 4);
   const extra: Record<string, unknown> = {};
 
-  spz.parseSplats(
+  await spz.parseSplats(
     (index, x, y, z) => {
       setPackedSplatCenter(packedArray, index, x, y, z);
     },


### PR DESCRIPTION
This PR replaces the usage of `fflate` with [`DecompressionStream`](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream) for decompressing `.spz` files. This lets the browser handle the decompression, yielding a noticeable improvement in loading times (measured in Chromium):

| Example | Main | DecompressionStream |  |
|--------------|---------|-----------------------------------|---------|
| Hello World | 341 ms | 177 ms | -48% |
| WebXR | 404 ms | 206 ms | -49% |
| Splat Transition | 284 ms | 127 ms | -55% |
|                              | 378 ms | 195 ms | -48% |
|                              | 837 ms | 470 ms | -44% |

:warning: The Compression Streams API is inherently asynchronous, but `Gunzip` from `fflate` allowed for synchronous usage. This means that the interface for the `SpzReader` had to change. Since it's part of the [exported symbols](https://github.com/sparkjsdev/spark/blob/6f327a716ff89c47c53901faac14161b3a6af7fb/src/index.ts#L16), this impacts all user-code that use `SpzReader` directly.

**Before**
```js
const spz = new SpzReader({ fileBytes });
const numSplats = spz.numSplats;
// ... (allocate resources)
spz.parseSplats( ... )
```

**After**
```js
const spz = new SpzReader({ fileBytes });
await spz.parseHeader(); // Required to access properties like `numSplats`
const numSplats = spz.numSplats;
// ... (allocate resources)
await spz.parseSplats( ... )
```