### PR TITLE
Fix incorrect return type for tryPcSogsZip

### DIFF
--- a/src/SplatLoader.ts
+++ b/src/SplatLoader.ts
@@ -418,7 +418,7 @@ export function tryPcSogs(
 
 export function tryPcSogsZip(
   input: ArrayBuffer | Uint8Array,
-): { name: string; json: PcSogsJson } | undefined {
+): { name: string; json: PcSogsJson | PcSogsV2Json } | undefined {
   try {
     const fileBytes =
       input instanceof ArrayBuffer ? new Uint8Array(input) : input;


### PR DESCRIPTION
A small mistake slipped in with #179. The return type of `tryPcSogsZip` wasn't updated to include the `PcSogsV2Json` possibility. This PR fixes that