### PR TITLE
Copy originToWorld values instead of holding a reference in SplatAccumulator

### DIFF
--- a/src/SplatAccumulator.ts
+++ b/src/SplatAccumulator.ts
@@ -97,7 +97,7 @@ export class SplatAccumulator {
     }
 
     this.splats.numSplats = numSplats;
-    this.toWorld = originToWorld;
+    this.toWorld.copy(originToWorld);
     this.mapping = generators;
     return updated !== 0;
   }


### PR DESCRIPTION
The `SplatAccumulator` keeps track of a `toWorld` matrix. However this was done by holding onto a reference to the matrix passed to `generateSplats`. When this matrix is updated outside the accumulator, it holds newer values. This in turn causes origin update checks to incorrectly fail in `SparkRenderer`, preventing the splats from being updated when they should.

See the following reported issue on the Spark Discord server: https://discord.com/channels/1374903240084426855/1379471336329576499/1427230168447193089

This PR changes it so that the values of the matrix are copied over instead.