### PR TITLE
Fix `build_rust_wasm.sh` script (correct shebang, don't require rustup)

### DIFF
--- a/rust/build_rust_wasm.sh
+++ b/rust/build_rust_wasm.sh
@@ -1,20 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Check if "rustup" tool is installed
-if ! command -v rustup &> /dev/null; then
+WASM_TARGET="$(rustc --print sysroot 2>/dev/null)/lib/rustlib/wasm32-unknown-unknown"
+# Check if "rustup" tool is installed, or the wasm32-unknown-unknown target aleady exists,
+# in which case it's very likely that the required toolchain exists
+if ! [ -d "$WASM_TARGET" ] && (! command -v rustup &> /dev/null); then
     echo "Rust tool 'rustup' not found! Please install Rust to build."
     echo "Visit Rust installation page: https://www.rust-lang.org/tools/install"
     echo "- Likely install one-liner: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+    echo "If you're using rust without rustup, make sure that the target 'wasm32-unknown-unknown' is installed"
     exit 1
 fi
 
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 
-# Make sure Rust wasm target is installed
-rustup target add wasm32-unknown-unknown
+if ! [ -d "$WASM_TARGET" ]; then
+    # Make sure Rust wasm target is installed
+    rustup target add wasm32-unknown-unknown
+fi
 
 # Make sure wasm-pack is installed
-cargo install wasm-pack
+if ! command -v wasm-pack &> /dev/null; then
+    cargo install wasm-pack
+fi
 
 cd spark-internal-rs
 


### PR DESCRIPTION
`#!/bin/bash` is non-standard, `#!/usr/bin/env bash` should be safer as it's standardized, as `/bin/bash` for instance doesn't exist on my system.

Additionally there are users (like me... this likely concerns a few NixOS users) who aren't using rustup, I've extended the script, such that it checks whether the rust target directory exists, in which case it's *very* likely that the required rust toolchain/target is on the system.
Similar for `wasm-pack` which might already be installed on the system without using `cargo install`.