### PR TITLE
Fix reference counting for SplatAccumulator during updates

### DIFF
--- a/src/PackedSplats.ts
+++ b/src/PackedSplats.ts
@@ -464,7 +464,7 @@ export class PackedSplats {
     let maxSplats = 0;
     const mapping = splatCounts.map((numSplats) => {
       const base = maxSplats;
-      // Generation happens in horizonal row chunks, so round up to full width
+      // Generation happens in horizontal row chunks, so round up to full width
       const rounded = Math.ceil(numSplats / SPLAT_TEX_WIDTH) * SPLAT_TEX_WIDTH;
       maxSplats += rounded;
       return { base, count: numSplats };

--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -314,6 +314,7 @@ export class SparkRenderer extends THREE.Mesh {
     this.splatEncoding = options.splatEncoding ?? { ...DEFAULT_SPLAT_ENCODING };
 
     this.active = new SplatAccumulator();
+    this.active.refCount = 1;
     this.accumulatorCount = 1;
     this.freeAccumulators = [];
     // Start with the minimum of 2 total accumulators
@@ -765,7 +766,7 @@ export class SparkRenderer extends THREE.Mesh {
       // minimum co-orientation (dot product of quaternions)
       const originChanged = !withinCoorientDist({
         matrix1: originToWorld,
-        matrix2: this.active.toWorld,
+        matrix2: accumulator.toWorld,
         maxDistance: 0.00001,
         minCoorient: 0.99999,
       });

--- a/src/SparkViewpoint.ts
+++ b/src/SparkViewpoint.ts
@@ -479,9 +479,15 @@ export class SparkViewpoint {
         // Splat mapping has not changed, so reuse the existing sorted
         // geometry to show updates faster. We will still fire off
         // a re-sort if necessary. First release old accumulator.
+        accumulator.refCount += 1;
         this.spark.releaseAccumulator(this.display.accumulator);
         this.display.accumulator = accumulator;
+        this.display.viewToWorld.copy(this.viewToWorld);
         displayed = true;
+
+        if (this.spark.viewpoint === this) {
+          this.spark.prepareViewpoint(this);
+        }
       }
     }
 
@@ -509,15 +515,12 @@ export class SparkViewpoint {
     }
 
     if (accumulator) {
-      // Hold a reference to the accumulator so it isn't released
+      // Hold a reference to the accumulator for sorting
       accumulator.refCount += 1;
     }
 
-    if (
-      accumulator &&
-      this.pending?.accumulator &&
-      this.pending.accumulator !== this.display?.accumulator
-    ) {
+    if (this.pending?.accumulator) {
+      // Release the reference of the pending accumulator
       this.spark.releaseAccumulator(this.pending.accumulator);
     }
     this.pending = { accumulator, viewToWorld: this.viewToWorld, displayed };
@@ -533,9 +536,10 @@ export class SparkViewpoint {
       }
 
       const { viewToWorld, displayed } = this.pending;
-      let accumulator = this.pending.accumulator ?? this.display?.accumulator;
+      let accumulator = this.pending.accumulator;
       if (!accumulator) {
-        accumulator = this.spark.active;
+        // Hold a reference to the accumulator while sorting
+        accumulator = this.display?.accumulator ?? this.spark.active;
         accumulator.refCount += 1;
       }
       this.pending = null;
@@ -546,6 +550,10 @@ export class SparkViewpoint {
       this.sorting = { viewToWorld };
       await this.sortUpdate({ accumulator, viewToWorld, displayed });
       this.sorting = null;
+
+      // Release the reference to the accumulator
+      this.spark.releaseAccumulator(accumulator);
+
       // Continue in loop with any queued sort
     }
   }
@@ -668,6 +676,8 @@ export class SparkViewpoint {
     displayed?: boolean;
   }) {
     if (!this.display) {
+      // Hold a reference to the accumulator while part of display
+      accumulator.refCount += 1;
       this.display = {
         accumulator,
         viewToWorld,
@@ -675,6 +685,9 @@ export class SparkViewpoint {
       };
     } else {
       if (!displayed && accumulator !== this.display.accumulator) {
+        // Hold a reference to the new accumulator being displayed
+        accumulator.refCount += 1;
+        // Release the reference to the previously displayed accumulator
         this.spark.releaseAccumulator(this.display.accumulator);
         this.display.accumulator = accumulator;
       }


### PR DESCRIPTION
While looking into #192 and #193 I noticed the reference counting of `SplatAccumulators` wasn't always correct. There were several ways it could go wrong, resulting in a range of issues. Luckily the resulting changeset is small, but tracking them down wasn't so easy. With these changes the ref counting should work correctly. There's still some possibilities for viewpoints to keep hold of accumulators starving the `SparkRenderer`.

The following changes were made:
 * Initialize the first accumulator with a `refCount` of 1, as the `SparkRenderer` immediately uses it as its `active` accumulator
 * Determine `originChanged` between current `viewToWorld` and the `viewToWorld` of the newly retrieved accumulator. Previously this compared to the _active_ accumulator, but the one retrieved from the pool might be older
 * Let `SparkViewpoint` keep track of its two references (`pending.accumulator` and `display.accumulator`). Before it kept a maximum of 1 reference, but since sorting happens asynchronous there could be in-flight sorting operations using an `accumulator` that was already released.
 * When the new accumulator has correspondence with the previous one, also update the `viewToWorld` and trigger a `prepareViewpoint`. Otherwise there'd be a window for a `SparkViewpoint` to have mismatched `accumulator` and `viewToWorld`