### PR TITLE
Fix ref counting and originToWorld in `SparkViewpoint.prepare`

### DIFF
--- a/src/SparkViewpoint.ts
+++ b/src/SparkViewpoint.ts
@@ -302,7 +302,9 @@ export class SparkViewpoint {
     while (update ?? true) {
       // Force an update, possibly with origin centered at this camera
       // to yield the best quality output.
-      const originToWorld = forceOrigin ? this.viewToWorld : undefined;
+      const originToWorld = forceOrigin
+        ? this.viewToWorld
+        : this.spark.matrixWorld;
       const updated = this.spark.updateInternal({ scene, originToWorld });
       if (updated) {
         break;
@@ -312,10 +314,11 @@ export class SparkViewpoint {
     }
 
     const accumulator = this.spark.active;
-    if (accumulator !== this.display?.accumulator) {
-      this.spark.active.refCount += 1;
-    }
+    // Hold reference to accumulator while sorting
+    accumulator.refCount += 1;
     await this.sortUpdate({ accumulator, viewToWorld: this.viewToWorld });
+    // Release accumulator reference
+    this.spark.releaseAccumulator(accumulator);
   }
 
   // Render out the viewpoint to the view target RGBA buffer.


### PR DESCRIPTION
See #205 

The `prepare` method of `SparkViewpoint` increased the `refCount` of the active accumulator in case it wasn't used in the viewpoint's display state. However the display reference is already covered, resulting in double counting this reference. At the same time there's no guarantee the viewpoint holds _any_ reference when `sortUpdate` is called. To resolve this a temporary reference is held.

Additionally there was a bug where the `prepare` method would default to not providing an `originToWorld` matrix. This causes the `SparkRenderer` to use the current `toWorld` of the active accumulator. This works as long as the `SparkRenderer` hasn't been moved, but renders incorrectly in case it did. See following scenario:
```js
// Move camera with spark renderer
camera.position.x += 10.0;
await viewpoint.prepare({ scene, camera }); // Prepares for an outdated SparkRenderer position
renderer.render(scene, camera); // Triggers a new update, renders incorrectly
```

One thing that remains tricky with regards to `prepare` is that it directly calls `sortUpdate`, ignoring any ongoing sort operation or pending sort operation. This makes it possible for `sortUpdate` to throw an error, breaking the ref counting.