### PR TITLE
Add an option to use linearToOutputTexel.

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -399,6 +399,8 @@ export class SparkRenderer extends THREE.Mesh {
       time: { value: 0 },
       // Delta time in seconds since last frame
       deltaTime: { value: 0 },
+      // Whether to use three.js's built-in linearToOutputTexel function instead of encodeLinear.
+      useLinearToOutputTexel: { value: false },
       // Whether to encode Gsplat with linear RGB (for environment mapping)
       encodeLinear: { value: false },
       // Debug flag that alternates each frame
@@ -536,6 +538,7 @@ export class SparkRenderer extends THREE.Mesh {
       | THREE.OrthographicCamera;
     this.uniforms.near.value = typedCamera.near;
     this.uniforms.far.value = typedCamera.far;
+    this.uniforms.useLinearToOutputTexel.value = viewpoint.useLinearToOutputTexel;
     this.uniforms.encodeLinear.value = viewpoint.encodeLinear;
     this.uniforms.maxStdDev.value = this.maxStdDev;
     this.uniforms.minPixelRadius.value = this.minPixelRadius;

--- a/src/SparkViewpoint.ts
+++ b/src/SparkViewpoint.ts
@@ -150,6 +150,7 @@ export class SparkViewpoint {
   target?: THREE.WebGLRenderTarget;
   private back?: THREE.WebGLRenderTarget;
   onTextureUpdated?: (texture: THREE.Texture) => void;
+  useLinearToOutputTexel = false;
   encodeLinear = false;
   superXY = 1;
   private superPixels?: Uint8Array;

--- a/src/shaders/splatDefines.glsl
+++ b/src/shaders/splatDefines.glsl
@@ -35,11 +35,17 @@ float pow8(float x) {
 }
 
 vec3 srgbToLinear(vec3 rgb) {
-    return pow(rgb, vec3(2.2));
+    // See https://github.com/mrdoob/three.js/blob/e04b9f7bd7f5b17103339d343168bfab2d6e0ace/src/math/ColorManagement.js#L205
+    vec3 linearLow = rgb * 0.0773993808;
+    vec3 linearHigh = pow(rgb * 0.9478672986 + 0.0521327014, vec3(2.4));
+    return mix(linearLow, linearHigh, greaterThanEqual(rgb, vec3(0.04045)));
 }
 
 vec3 linearToSrgb(vec3 rgb) {
-    return pow(rgb, vec3(1.0 / 2.2));
+    // See https://github.com/mrdoob/three.js/blob/e04b9f7bd7f5b17103339d343168bfab2d6e0ace/src/math/ColorManagement.js#L211
+    vec3 srgbLow = rgb * 12.92;
+    vec3 srgbHigh = 1.055 * (pow(rgb, vec3(0.41666)) - 0.055);
+    return mix(srgbLow, srgbHigh, greaterThanEqual(rgb, vec3(0.0031308)));
 }
 
 // uint encodeQuatXyz888(vec4 q) {

--- a/src/shaders/splatFragment.glsl
+++ b/src/shaders/splatFragment.glsl
@@ -7,6 +7,7 @@ precision highp int;
 
 uniform float near;
 uniform float far;
+uniform bool useLinearToOutputTexel;
 uniform bool encodeLinear;
 uniform float time;
 uniform bool debugFlag;
@@ -69,7 +70,7 @@ void main() {
     if (rgba.a < minAlpha) {
         discard;
     }
-    if (encodeLinear) {
+    if (useLinearToOutputTexel || encodeLinear) {
         rgba.rgb = srgbToLinear(rgba.rgb);
     }
 
@@ -88,6 +89,9 @@ void main() {
             discard;
         }
     } else {
+        if (useLinearToOutputTexel) {
+            rgba = linearToOutputTexel( rgba );
+        }
         #ifdef PREMULTIPLIED_ALPHA
             fragColor = vec4(rgba.rgb * rgba.a, rgba.a);
         #else


### PR DESCRIPTION
When a render target is set, threejs automatically change their shaders to output in Linear color space using linearToOutputTexel: https://github.com/mrdoob/three.js/blob/e04b9f7bd7f5b17103339d343168bfab2d6e0ace/src/renderers/WebGLRenderer.js#L2198

However, with Sparkjs, we need to manually set `encodeLinear` or else we get a washed out image like this:
<img width="1568" height="1770" alt="image" src="https://github.com/user-attachments/assets/5915f46f-8b39-4b07-8c1f-2d7f187371bc" />

With this option, we now have the option of setting `sparkRenderer.defaultView.useLinearToOutputTexel = true;` and the Spark fragment shader will automatically output in the correct color space the same way that three.js's built-in shaders do.