### PR TITLE
refactor: use magic-string for proper source maps in WASM fix

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,8 @@ function fixWasmDataUrl(): Plugin {
 
       const s = new MagicString(code);
       for (const match of matches) {
-        const start = match.index!;
+        if (match.index === undefined) continue;
+        const start = match.index;
         const end = start + match[0].length;
         const replacement = `new URL(${match[1]})`;
         s.overwrite(start, end, replacement);


### PR DESCRIPTION
Improve the WASM data URL fix to use magic-string for accurate source map generation. This eliminates build warnings and ensures proper debugging support.

- Replace string.replace() with MagicString.overwrite()
- Return both code and source map from renderChunk
- Uses existing magic-string dependency (via vite-plugin-dts)