### PR TITLE
Ensure splatDefines ShaderChunk is ready when using Readback before SparkRenderer

### DIFF
--- a/src/PackedSplats.ts
+++ b/src/PackedSplats.ts
@@ -19,7 +19,7 @@ import {
   outputPackedSplat,
 } from "./dyno";
 import { TPackedSplats, definePackedSplats } from "./dyno/splats";
-import computeUvec4Template from "./shaders/computeUvec4.glsl";
+import { getShaders } from "./shaders";
 import { getTextureSize, setPackedSplat, unpackSplat } from "./utils";
 
 export type SplatEncoding = {
@@ -574,7 +574,7 @@ export class PackedSplats {
       );
       if (!PackedSplats.programTemplate) {
         PackedSplats.programTemplate = new DynoProgramTemplate(
-          computeUvec4Template,
+          getShaders().computeUvec4Template,
         );
       }
       // Create a program from the template and graph

--- a/src/Readback.ts
+++ b/src/Readback.ts
@@ -4,7 +4,7 @@ import { FullScreenQuad } from "three/addons/postprocessing/Pass.js";
 import { SPLAT_TEX_HEIGHT, SPLAT_TEX_WIDTH } from "./defines";
 import { type Dyno, OutputRgba8, dynoBlock } from "./dyno";
 import { DynoProgram, DynoProgramTemplate } from "./dyno/program";
-import computeVec4Template from "./shaders/computeVec4.glsl";
+import { getShaders } from "./shaders";
 import { getTextureSize } from "./utils";
 
 // Readback can be used to run a Dyno program that maps an index to a 32-bit
@@ -107,7 +107,9 @@ export class Readback {
         },
       );
       if (!Readback.programTemplate) {
-        Readback.programTemplate = new DynoProgramTemplate(computeVec4Template);
+        Readback.programTemplate = new DynoProgramTemplate(
+          getShaders().computeVec4Template,
+        );
       }
       // Create a program from the template and graph
       program = new DynoProgram({

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -1,5 +1,7 @@
 import * as THREE from "three";
 
+import computeUvec4Template from "./shaders/computeUvec4.glsl";
+import computeVec4Template from "./shaders/computeVec4.glsl";
 import splatDefines from "./shaders/splatDefines.glsl";
 import splatFragment from "./shaders/splatFragment.glsl";
 import splatVertex from "./shaders/splatVertex.glsl";
@@ -13,6 +15,8 @@ export function getShaders(): Record<string, string> {
     shaders = {
       splatVertex,
       splatFragment,
+      computeVec4Template,
+      computeUvec4Template,
     };
   }
   return shaders;


### PR DESCRIPTION
Fixes #228 

`Readback` depends on the `splatDefines` shader chunk, but this is only initialized by the `SparkRenderer`. This PR ensures that whenever a shader (splat or compute) is referenced, it goes through `getShaders` which ensures the `splatDefines` shader chunk is present.