### PR TITLE
Add mobile joystick example

### DIFF
--- a/examples/mobile-joystick/index.html
+++ b/examples/mobile-joystick/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <title>Spark • Mobile Joystick</title>
+  <style>
+    body {
+      margin: 0;
+      overflow: hidden;
+      touch-action: none;
+    }
+    #info {
+      position: fixed;
+      top: 10px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: rgba(0, 0, 0, 0.7);
+      color: #fff;
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-family: system-ui, sans-serif;
+      font-size: 14px;
+      text-align: center;
+      z-index: 100;
+      pointer-events: none;
+    }
+    #info.mobile {
+      background: rgba(40, 120, 200, 0.8);
+    }
+  </style>
+</head>
+
+<body>
+  <div id="info">Loading...</div>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.179.0/three.module.js",
+        "@sparkjsdev/spark": "/dist/spark.module.js"
+      }
+    }
+  </script>
+  <script type="module">
+    import * as THREE from "three";
+    import { NewSparkRenderer, SplatMesh, SparkControls } from "@sparkjsdev/spark";
+    import { getAssetFileURL } from "/examples/js/get-asset-url.js";
+    import { initMobileControls, getMobileInput, isMobileDevice } from "./mobile-joystick.js";
+
+    // Scene setup
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    document.body.appendChild(renderer.domElement);
+
+    // Handle window resize
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    // Camera control group
+    const cameraRig = new THREE.Group();
+    cameraRig.add(camera);
+    scene.add(cameraRig);
+
+    // Create Spark renderer (required for splats to render)
+    const spark = new NewSparkRenderer({ renderer });
+    scene.add(spark);
+
+    // Load the valley environment
+    const splatURL = await getAssetFileURL("valley.spz");
+    const splat = new SplatMesh({ url: splatURL });
+    splat.quaternion.set(1, 0, 0, 0);
+    splat.position.set(0, 0, -3);
+    scene.add(splat);
+
+    // Start position inside the valley
+    cameraRig.position.set(0, 1.6, 0);
+
+    // Desktop controls (mouse/keyboard)
+    const controls = new SparkControls({ canvas: renderer.domElement });
+
+    // Mobile joystick
+    const isMobile = isMobileDevice();
+    const info = document.getElementById('info');
+
+    if (isMobile) {
+      initMobileControls({
+        joystickSize: 140,
+        knobSize: 60,
+        marginLeft: 40,
+        marginBottom: 40,
+      });
+      info.textContent = '🕹️ Use joystick to move • Drag to look around';
+      info.classList.add('mobile');
+    } else {
+      info.textContent = 'WASD to move • Drag to look around';
+    }
+
+    // Movement settings
+    const MOVE_SPEED = 2.0;
+
+    // Animation loop
+    let lastTime = performance.now();
+    renderer.setAnimationLoop(function animate(time) {
+      const deltaTime = (time - lastTime) / 1000;
+      lastTime = time;
+
+      // Update desktop controls (handles mouse look on both desktop & mobile)
+      controls.update(cameraRig);
+
+      // Apply mobile joystick movement
+      if (isMobile) {
+        const input = getMobileInput();
+        if (input.x !== 0 || input.y !== 0) {
+          const move = new THREE.Vector3(input.x, 0, input.y);
+          move.multiplyScalar(MOVE_SPEED * deltaTime);
+          move.applyQuaternion(cameraRig.quaternion);
+          cameraRig.position.add(move);
+        }
+      }
+
+      renderer.render(scene, camera);
+    });
+  </script>
+</body>
+
+</html>

--- a/examples/mobile-joystick/mobile-joystick.js
+++ b/examples/mobile-joystick/mobile-joystick.js
@@ -1,0 +1,235 @@
+/**
+ * Mobile Controls - Virtual Joystick
+ *
+ * Provides touch-based movement controls for mobile devices.
+ *
+ * Usage:
+ *   import { initMobileControls, getMobileInput, isMobileDevice } from './mobile-joystick.js';
+ *
+ *   if (isMobileDevice()) {
+ *       initMobileControls();
+ *   }
+ *
+ *   // In your update loop:
+ *   const input = getMobileInput();
+ *   // input.x: -1 to 1 (left/right)
+ *   // input.y: -1 to 1 (forward/back, positive = backward)
+ *   // input.active: boolean (is joystick being touched)
+ */
+
+// Configuration
+const CONFIG = {
+  joystickSize: 120,
+  knobSize: 50,
+  deadzone: 0.15,
+  marginLeft: 30,
+  marginBottom: 30,
+  outerColor: "rgba(255, 255, 255, 0.2)",
+  outerBorder: "rgba(255, 255, 255, 0.4)",
+  knobColor: "rgba(255, 255, 255, 0.5)",
+  knobActiveColor: "rgba(100, 150, 255, 0.7)",
+};
+
+// State
+let initialized = false;
+let enabled = true;
+let joystickContainer = null;
+let joystickKnob = null;
+let activeTouch = null;
+let joystickCenter = { x: 0, y: 0 };
+let currentInput = { x: 0, y: 0, active: false };
+
+/**
+ * Check if the current device is a mobile/touch device (but NOT a VR headset)
+ */
+export function isMobileDevice() {
+  if (/OculusBrowser|Quest|Oculus/i.test(navigator.userAgent)) {
+    return false;
+  }
+  return (
+    "ontouchstart" in window ||
+    navigator.maxTouchPoints > 0 ||
+    /Android|iPhone|iPad|iPod|webOS|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent,
+    )
+  );
+}
+
+/**
+ * Initialize mobile controls
+ */
+export function initMobileControls(options = {}) {
+  if (initialized) return;
+  Object.assign(CONFIG, options);
+  createJoystickUI();
+  attachEventListeners();
+  initialized = true;
+  console.log("[MobileControls] Initialized");
+}
+
+/**
+ * Get current mobile input state
+ */
+export function getMobileInput() {
+  if (!enabled || !initialized) {
+    return { x: 0, y: 0, active: false };
+  }
+  return { ...currentInput };
+}
+
+/**
+ * Enable or disable mobile controls
+ */
+export function setMobileControlsEnabled(value) {
+  enabled = value;
+  if (joystickContainer) {
+    joystickContainer.style.display = enabled ? "block" : "none";
+  }
+  if (!enabled) {
+    currentInput = { x: 0, y: 0, active: false };
+  }
+}
+
+function createJoystickUI() {
+  joystickContainer = document.createElement("div");
+  joystickContainer.id = "mobile-joystick";
+  joystickContainer.style.cssText = `
+        position: fixed;
+        left: ${CONFIG.marginLeft}px;
+        bottom: ${CONFIG.marginBottom}px;
+        width: ${CONFIG.joystickSize}px;
+        height: ${CONFIG.joystickSize}px;
+        z-index: 1000;
+        touch-action: none;
+        pointer-events: auto;
+    `;
+
+  const joystickOuter = document.createElement("div");
+  joystickOuter.style.cssText = `
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        background: ${CONFIG.outerColor};
+        border: 2px solid ${CONFIG.outerBorder};
+        box-sizing: border-box;
+    `;
+
+  joystickKnob = document.createElement("div");
+  joystickKnob.style.cssText = `
+        position: absolute;
+        width: ${CONFIG.knobSize}px;
+        height: ${CONFIG.knobSize}px;
+        border-radius: 50%;
+        background: ${CONFIG.knobColor};
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        transition: background 0.1s;
+    `;
+
+  joystickOuter.appendChild(joystickKnob);
+  joystickContainer.appendChild(joystickOuter);
+  document.body.appendChild(joystickContainer);
+
+  updateJoystickCenter();
+}
+
+function updateJoystickCenter() {
+  if (!joystickContainer) return;
+  const rect = joystickContainer.getBoundingClientRect();
+  joystickCenter = {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  };
+}
+
+function attachEventListeners() {
+  window.addEventListener("resize", updateJoystickCenter);
+  window.addEventListener("orientationchange", () => {
+    setTimeout(updateJoystickCenter, 100);
+  });
+
+  joystickContainer.addEventListener("touchstart", handleTouchStart, {
+    passive: false,
+  });
+  document.addEventListener("touchmove", handleTouchMove, { passive: false });
+  document.addEventListener("touchend", handleTouchEnd, { passive: false });
+  document.addEventListener("touchcancel", handleTouchEnd, { passive: false });
+}
+
+function handleTouchStart(e) {
+  if (!enabled || activeTouch !== null) return;
+
+  const touch = e.changedTouches[0];
+  activeTouch = touch.identifier;
+
+  updateJoystickCenter();
+  updateJoystickPosition(touch.clientX, touch.clientY);
+
+  joystickKnob.style.background = CONFIG.knobActiveColor;
+  currentInput.active = true;
+
+  e.preventDefault();
+}
+
+function handleTouchMove(e) {
+  if (!enabled || activeTouch === null) return;
+
+  for (const touch of e.changedTouches) {
+    if (touch.identifier === activeTouch) {
+      updateJoystickPosition(touch.clientX, touch.clientY);
+      e.preventDefault();
+      break;
+    }
+  }
+}
+
+function handleTouchEnd(e) {
+  if (activeTouch === null) return;
+
+  for (const touch of e.changedTouches) {
+    if (touch.identifier === activeTouch) {
+      resetJoystick();
+      break;
+    }
+  }
+}
+
+function updateJoystickPosition(touchX, touchY) {
+  const maxRadius = (CONFIG.joystickSize - CONFIG.knobSize) / 2;
+
+  let dx = touchX - joystickCenter.x;
+  let dy = touchY - joystickCenter.y;
+
+  const distance = Math.sqrt(dx * dx + dy * dy);
+  if (distance > maxRadius) {
+    dx = (dx / distance) * maxRadius;
+    dy = (dy / distance) * maxRadius;
+  }
+
+  const knobX = 50 + (dx / maxRadius) * 50;
+  const knobY = 50 + (dy / maxRadius) * 50;
+  joystickKnob.style.left = `${knobX}%`;
+  joystickKnob.style.top = `${knobY}%`;
+
+  let inputX = dx / maxRadius;
+  let inputY = dy / maxRadius;
+
+  if (Math.abs(inputX) < CONFIG.deadzone) inputX = 0;
+  if (Math.abs(inputY) < CONFIG.deadzone) inputY = 0;
+
+  currentInput.x = inputX;
+  currentInput.y = inputY;
+}
+
+function resetJoystick() {
+  activeTouch = null;
+  currentInput = { x: 0, y: 0, active: false };
+
+  if (joystickKnob) {
+    joystickKnob.style.left = "50%";
+    joystickKnob.style.top = "50%";
+    joystickKnob.style.background = CONFIG.knobColor;
+  }
+}


### PR DESCRIPTION
Virtual joystick for mobile use. Includes checks to avoid being included in VR. Will leave up to you whether you want to keep as an example or convert to .ts and include in the base. But I think this is quite useful to have if you're building anything interactive for mobile. 