### PR TITLE
fix: forward fileType to SplatLoader in PackedSplats.asyncInitialize

### DIFF
--- a/src/PackedSplats.ts
+++ b/src/PackedSplats.ts
@@ -218,6 +218,7 @@ export class PackedSplats {
     if (url) {
       const loader = new SplatLoader();
       loader.packedSplats = this;
+      loader.fileType = options.fileType;
       await loader.loadAsync(url);
     } else if (fileBytes) {
       const unpacked = await unpackSplats({


### PR DESCRIPTION
Fixes #233 

Bug: When constructing a SplatMesh with url + fileType, the fileType is never forwarded to the internal SplatLoader instance created in PackedSplats.asyncInitialize(). This causes URLs without recognizable extensions (e.g. Blob URLs) to fail with Unknown splat file type: undefined.

Fix: Add loader.fileType = options.fileType before calling loader.loadAsync(url).