### PR TITLE
Fix `fileBytes` loading for `.splat` files

### DIFF
--- a/rust/spark-lib/src/decoder.rs
+++ b/rust/spark-lib/src/decoder.rs
@@ -348,7 +348,7 @@ impl SplatFileType {
         match enum_str {
             "ply" => Ok(Self::PLY),
             "spz" => Ok(Self::SPZ),
-            "antisplat" => Ok(Self::ANTISPLAT),
+            "antisplat" | "splat" => Ok(Self::ANTISPLAT),
             "ksplat" => Ok(Self::KSPLAT),
             "sogs" => Ok(Self::SOGS),
             "rad" => Ok(Self::RAD),


### PR DESCRIPTION
## Problem

Loading `.splat` files via `fileBytes` + `fileType: "splat"` fails with

```
Uncaught (in promise) Invalid file type: splat
```

Loading via `url` works correctly.

## Cause

There is a mismatch between the TypeScript `SplatFileType` enum and the Rust `from_enum_str` function.

- **TypeScript side:** `SplatFileType.SPLAT = "splat"` string is passed to the worker.
  - https://github.com/sparkjsdev/spark/blob/v2.0.0-preview/src/worker.ts#L262 
- **Rust side:** `from_enum_str` only accepts `"antisplat"` not `"splat"`.
  - https://github.com/sparkjsdev/spark/blob/v2.0.0-preview/rust/spark-worker-rs/src/lib.rs#L104
  - https://github.com/sparkjsdev/spark/blob/v2.0.0-preview/rust/spark-lib/src/decoder.rs#L347-L357

when using `fileBytes`, the `fileType` string goes directly through `from_enum_str("splat")`, which has no matching and returns an error.

## Fix

Added `"splat"` as  `ANTISPLAT` in `from_enum_str`

```rust
"antisplat" | "splat" => Ok(Self::ANTISPLAT),
```

This aligns `from_enum_str` with the existing behavior of `from_extension`, which already maps `"splat"` to `ANTISPLAT`.
https://github.com/sparkjsdev/spark/blob/v2.0.0-preview/rust/spark-lib/src/decoder.rs#L363

Before
<img width="1905" height="917"  src="https://github.com/user-attachments/assets/70a22d54-0ff6-496e-b51d-e9e2b57842a5" />

After
<img width="1898" height="915"  src="https://github.com/user-attachments/assets/1d8ce1e0-4aae-4faa-8e07-0f45b56040b2" />

