### PR TITLE
fix: rename log-depth shader define and bump three to 0.183.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "onchange": "7.1.0",
         "spark-internal-rs": "file:rust/spark-internal-rs/pkg",
         "stats.js": "^0.17.0",
-        "three": "^0.178.0",
+        "three": "^0.183.2",
         "ts-node": "10.9.2",
         "typescript": "^5.7.3",
         "vite": "^6.0.11",
@@ -27,7 +27,7 @@
         "vite-plugin-glsl": "^1.3.1"
       },
       "peerDependencies": {
-        "three": "^0.178.0"
+        "three": "^0.183.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2634,9 +2634,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.178.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
-      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@types/three": "0.178.0",
+        "@types/three": "0.183.1",
         "lefthook": "1.11.12",
         "lil-gui": "^0.20.0",
         "onchange": "7.1.0",
@@ -1238,19 +1238,19 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.178.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.178.0.tgz",
-      "integrity": "sha512-1IpVbMKbEAAWjyn0VTdVcNvI1h1NlTv3CcnwMr3NNBv/gi3PL0/EsWROnXUEkXBxl94MH5bZvS8h0WnBRmR/pQ==",
+      "version": "0.183.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
+      "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
-        "@types/webxr": "*",
+        "@types/webxr": ">=0.5.17",
         "@webgpu/types": "*",
         "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
+        "meshoptimizer": "~1.0.1"
       }
     },
     "node_modules/@types/webxr": {
@@ -2183,9 +2183,9 @@
       "dev": true
     },
     "node_modules/meshoptimizer": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
-      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
+      "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@types/three": "0.178.0",
+    "@types/three": "0.183.1",
     "lefthook": "1.11.12",
     "lil-gui": "^0.20.0",
     "onchange": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lil-gui": "^0.20.0",
     "onchange": "7.1.0",
     "stats.js": "^0.17.0",
-    "three": "^0.178.0",
+    "three": "^0.183.2",
     "ts-node": "10.9.2",
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
@@ -61,7 +61,7 @@
     "fflate": "^0.8.2"
   },
   "peerDependencies": {
-    "three": "^0.178.0"
+    "three": "^0.183.2"
   },
   "keywords": ["3d", "three.js", "gsplats", "3dgs", "gaussian", "splats"]
 }

--- a/src/PackedSplats.ts
+++ b/src/PackedSplats.ts
@@ -243,12 +243,10 @@ export class PackedSplats {
   dispose() {
     if (this.target) {
       this.target.dispose();
-      this.target.texture.source.data = null;
       this.target = null;
     }
     if (this.source) {
       this.source.dispose();
-      this.source.source.data = null;
       this.source = null;
     }
 
@@ -264,7 +262,6 @@ export class PackedSplats {
         const texture = dyno.value;
         if (texture?.isTexture) {
           texture.dispose();
-          texture.source.data = null;
         }
       }
     }
@@ -542,7 +539,10 @@ export class PackedSplats {
         this.source.type = THREE.UnsignedIntType;
         this.source.internalFormat = "RGBA32UI";
         this.source.needsUpdate = true;
-      } else if (this.packedArray.buffer !== this.source.image.data.buffer) {
+      } else if (
+        !this.source.image.data ||
+        this.packedArray.buffer !== this.source.image.data.buffer
+      ) {
         // The source texture is the right size, update the data
         this.source.image.data = new Uint8Array(this.packedArray.buffer);
       }

--- a/src/RgbaArray.ts
+++ b/src/RgbaArray.ts
@@ -141,7 +141,10 @@ export class RgbaArray {
         this.source.type = THREE.UnsignedByteType;
         this.source.internalFormat = "RGBA8";
         this.source.needsUpdate = true;
-      } else if (this.array.buffer !== this.source.image.data.buffer) {
+      } else if (
+        !this.source.image.data ||
+        this.array.buffer !== this.source.image.data.buffer
+      ) {
         this.source.image.data = new Uint8Array(this.array.buffer);
       }
       this.source.needsUpdate = true;

--- a/src/shaders/splatVertex.glsl
+++ b/src/shaders/splatVertex.glsl
@@ -36,7 +36,7 @@ uniform float focalAdjustment;
 uniform usampler2DArray packedSplats;
 uniform vec4 rgbMinMaxLnScaleMinMax;
 
-#ifdef USE_LOGDEPTHBUF
+#ifdef USE_LOGARITHMIC_DEPTH_BUFFER
     bool isPerspectiveMatrix( mat4 m ) {
       return m[ 2 ][ 3 ] == - 1.0;
     }


### PR DESCRIPTION
## Summary
- Rename deprecated Three.js shader define `USE_LOGDEPTHBUF` to `USE_LOGARITHMIC_DEPTH_BUFFER` in `src/shaders/splatVertex.glsl`.
- Update `three` from `^0.178.0` to `^0.183.2` in `package.json` (`devDependencies` and `peerDependencies`).
- Refresh `package-lock.json` for the dependency bump.

## Why
`USE_LOGDEPTHBUF` was renamed upstream in Three.js. This keeps Spark compatible with newer Three.js versions.