### PR TITLE
Clustered SH in RAD, 100x faster raycasting, soft LoD, on-demand rendering, and more

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -56,7 +56,7 @@
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
         "three/addons/": "/examples/js/vendor/three/examples/jsm/",
-        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "@sparkjsdev/spark": "/dist/spark.module.js",
         "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
@@ -106,6 +106,7 @@
       }),
     });
     grid.opacity = 0;
+    grid.visible = false;
     scene.add(grid);
 
     const stats = new Stats();
@@ -135,18 +136,21 @@
       loadFiles([...event.target.files]);
     };
 
+    let instructions = null;
     const guiOptions = {
       highDevicePixel: !isMobile(),
       stats: false,
       resetOnLoad: true,
       loadOffset: 0,
-      openCv: true,
+      coordSystem: "OpenGL",
       autoRotate: true,
       orbit: false,
       reversePointerDir: false,
       reversePointerSlide: false,
       backgroundColor: "#000000",
       viewBoundingBox: false,
+      showCones: false,
+      splatCount: "-",
       openFiles: () => {
         fileInput.click();
       },
@@ -172,10 +176,15 @@
     };
 
     function resetFrameQuaternion() {
-      if (guiOptions.openCv) {
+      if (guiOptions.coordSystem === "OpenCV") {
         frame.quaternion.set(1, 0, 0, 0);
-      } else {
+      } else if (guiOptions.coordSystem === "OpenGL") {
         frame.quaternion.set(0, 0, 0, 1);
+      } else if (guiOptions.coordSystem === "Z-up") {
+        frame.quaternion.set(-1, 0, 0, 1).normalize();
+      }
+      if (instructions) {
+        instructions.quaternion.copy(frame.quaternion).invert();
       }
     }
 
@@ -346,12 +355,12 @@
         for (const child of toRemove) {
           frame.remove(child);
         }
+        instructions = null;
         // Clear original file bytes when resetting
         inputs.length = 0;
         splatsFolder.foldersRecursive().forEach((child) => child.destroy());
       }
 
-      // guiOptions.openCv = true;
       guiOptions.autoRotate = false;
       resetFrameQuaternion();
       // writeOptions.filename = "";
@@ -447,7 +456,7 @@
     secondGui.add(guiOptions, "loadFromTextAction").name("Load from URL(s)");
 
     cameraFolder.add(guiOptions, "resetPose").name("Reset pose");
-    cameraFolder.add(guiOptions, "openCv").name("OpenCV coordinates")
+    cameraFolder.add(guiOptions, "coordSystem", ["OpenCV", "OpenGL", "Z-up"]).name("Coordinate system")
       .listen()
       .onChange(resetFrameQuaternion);
     cameraFolder.add(guiOptions, "autoRotate").name("Auto rotate")
@@ -490,12 +499,84 @@
     const splatExtra = {
       extSplats: true,
       lod: false,
-      // lodAbove: 0,
     };
 
-    gui.add(splatExtra, "lod").name("Create Level-of-Detail on load")
-    // gui.add(splatExtra, "lodAbove", 0, 100000000, 100000).name("LoD min splat count");
-    gui.add(spark, "lodSplatScale", 0.001, 3.0, 0.001).name("LoD splat scale").listen();
+    function makeConeMesh(fov0) {
+      const radius = 10;
+      const height = 10;
+      const segments = 32;
+      const geometry = new THREE.ConeGeometry(radius, height, segments, 1, true);
+      geometry.translate(0, -height / 2, 0);
+      geometry.rotateX(Math.PI / 2); // Now faces -Z
+
+      const edges = new THREE.EdgesGeometry(geometry);
+      return new THREE.LineSegments(
+        edges,
+        new THREE.LineBasicMaterial({ color: fov0 ? 0xffcc00 : 0x00ccff })
+      );
+    }
+
+    function makeConeCircles(fov0) {
+      const group = new THREE.Group();
+      const segments = 32;
+      const color = fov0 ? 0xffcc00 : 0x00ccff;
+      const material = new THREE.LineBasicMaterial({ color });
+
+      for (const z of [0.0625, 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0]) {
+        const geometry = new THREE.BufferGeometry();
+        const vertices = [];
+
+        for (let j = 0; j <= segments; ++j) {
+          const theta = (j / segments) * 2 * Math.PI;
+          const x = Math.cos(theta) * z;
+          const y = Math.sin(theta) * z;
+          vertices.push(x, y, -z);
+        }
+
+        geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+        const line = new THREE.Line(geometry, material);
+        group.add(line);
+      }
+
+      group.add(makeConeMesh(fov0));
+      return group;
+    }
+
+    const cone0Mesh = makeConeCircles(true);
+    cone0Mesh.visible = false;
+    scene.add(cone0Mesh);
+
+    const coneMesh = makeConeCircles(false);
+    coneMesh.visible = false;
+    scene.add(coneMesh);
+
+    function updateConeMeshes() {
+      const tan0 = Math.tan(0.5 * spark.coneFov0 * Math.PI / 180);
+      cone0Mesh.scale.set(tan0, tan0, 1);
+      const tan = Math.tan(0.5 * spark.coneFov * Math.PI / 180);
+      coneMesh.scale.set(tan, tan, 1);
+    }
+
+    const lodFolder = gui.addFolder("Level-of-Detail").close();
+    lodFolder.add(splatExtra, "lod").name("Create Level-of-Detail on load")
+    lodFolder.add(spark, "lodSplatScale", 0.001, 3.0, 0.001).name("LoD splat scale").listen();
+    lodFolder.add(guiOptions, "splatCount").name("Current splat count").listen();
+    lodFolder.add(spark, "coneFov0", 0.0, 170.0, 1.0).name("Cone Fov0").listen().onChange(updateConeMeshes);
+    lodFolder.add(spark, "coneFov", 0.0, 170.0, 1.0).name("Cone Fov").listen().onChange(updateConeMeshes);
+    lodFolder.add(guiOptions, "showCones").name("Show FOV cones").listen().onChange((show) => {
+      cone0Mesh.visible = show;
+      coneMesh.visible = show;
+    });
+    updateConeMeshes();
+    lodFolder.add(spark, "coneFoveate", 0.0, 1.0, 0.01).name("Cone Foveate").listen();
+    lodFolder.add(spark, "behindFoveate", 0.0, 1.0, 0.01).name("Behind Foveate").listen();
+    lodFolder.add(spark, "enableDriveLod").name("Enable LoD updates").listen();
+    lodFolder.add(spark, "lodInflate").name("Soften LoD splats").listen();
+
+    const pageColoring = dyno.dynoBool(false);
+    lodFolder.add(pageColoring, "value").name("Page Coloring").listen().onChange(() => {
+      updateFrameSplats();
+    });
 
     gui.add(guiOptions, "highDevicePixel").name("High DPI").onChange((value) => {
       setHighDpi(value);
@@ -504,7 +585,10 @@
       stats.dom.style.display = value ? "block" : "none";
     });
     gui.add(spark, "sortRadial").name("Radial sort").listen();
-    gui.add(grid, "opacity", 0, 1, 0.01).name("Grid opacity").listen();
+    // gui.add(spark, "enableRayEval").name("3DGUT/3DRT/HTGS").listen();
+    gui.add(grid, "opacity", 0, 1, 0.01).name("Grid opacity").listen().onChange((value) => {
+      grid.visible = value > 0;
+    });
     gui.add({
       logFocalDistance: 0.0,
     }, "logFocalDistance", -2, 2, 0.01).name("Ln(Focal distance)").onChange((value) => {
@@ -610,7 +694,7 @@
       return dyno.dynoBlock({ gsplat: dyno.Gsplat }, { gsplat: dyno.Gsplat }, ({ gsplat }) => {
         // Color by world normal if it's enabled
         let worldNormal = dyno.gsplatNormal(gsplat);
-        let { rgb, center, opacity } = dyno.splitGsplat(gsplat).outputs;
+        let { index, rgb, center, opacity } = dyno.splitGsplat(gsplat).outputs;
         // Compute vector from view to object coordinate in gsplat
         const worldToView = context.worldToView;
         const viewGsplat = worldToView.applyGsplat(gsplat);
@@ -621,6 +705,11 @@
         normal = dyno.select(sameDir, dyno.neg(worldNormal), worldNormal);
         const normalRgb = dyno.add(dyno.mul(normal, dyno.dynoConst("float", 0.5)), dyno.dynoConst("float", 0.5));
         rgb = dyno.select(normalColor, normalRgb, rgb);
+
+        const page = dyno.shr(index, dyno.dynoConst("int", 16));
+        let debugColor = dyno.debugColorHue(page);
+        debugColor = dyno.mul(debugColor, rgb)
+        rgb = dyno.mix(rgb, debugColor, dyno.float(pageColoring));
 
         // Zero out opacity if outside clip bounds
         const { x, y, z } = dyno.split(center).outputs;
@@ -700,14 +789,14 @@
         fontSize: 64,
         objectScale: 0.1 / 64,
       });
-      instructions.quaternion.set(1, 0, 0, 0);
+      instructions.quaternion.copy(frame.quaternion).invert();
       instructions.enableWorldToView = true;
       instructions.worldModifier = makeWorldModifier(instructions);
       instructions.updateGenerator();
       return instructions;
     }
 
-    const instructions = makeInstructions();
+    instructions = makeInstructions();
     addBoundingBoxHelper(instructions);
     frame.add(instructions);
 
@@ -800,7 +889,13 @@
       stats.begin();
 
       if (guiOptions.autoRotate) {
-        frame.rotation.y += deltaTime / 5000;
+        if (guiOptions.coordSystem === "OpenCV") {
+          frame.rotation.y = time / 5000;
+        } else if (guiOptions.coordSystem === "OpenGL") {
+          frame.rotation.y = -time / 5000;
+        } else if (guiOptions.coordSystem === "Z-up") {
+          frame.rotation.z = -time / 5000;
+        }
       }
 
       if (guiOptions.orbit) {
@@ -809,7 +904,15 @@
         controls.update(camera);
       }
 
+      const lodPos = spark.lastLod?.pos ?? new THREE.Vector3().copy(camera.position);
+      const lodQuat = spark.lastLod?.quat ?? new THREE.Quaternion().copy(camera.quaternion);
+      cone0Mesh.position.copy(lodPos);
+      cone0Mesh.quaternion.copy(lodQuat);
+      coneMesh.position.copy(lodPos);
+      coneMesh.quaternion.copy(lodQuat);
+
       renderer.render(scene, camera);
+      guiOptions.splatCount = `${spark.display.numSplats}`;
 
       stats.end();
     });

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10,6 +10,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -22,10 +33,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "autocfg"
@@ -34,24 +75,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "build-lod"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytemuck",
+ "pollster",
+ "serde_json",
  "spark-lib",
+ "wgpu",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -84,16 +202,121 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -107,10 +330,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glam"
 version = "0.30.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12d847aeb25f41be4c0ec9587d624e9cd631bc007a8fd7ce3f5851e064c6460"
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "half"
@@ -120,6 +409,91 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hnsw"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b9740ebf8769ec4ad6762cc951ba18f39bba6dfbc2fbbe46285f7539af79752"
+dependencies = [
+ "ahash 0.7.8",
+ "hashbrown 0.11.2",
+ "libm",
+ "num-traits",
+ "rand_core",
+ "smallvec",
+ "space",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -138,14 +512,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
+name = "jni-sys"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
 dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "libc"
@@ -154,10 +575,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
-name = "log"
-version = "0.4.27"
+name = "libloading"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -172,6 +624,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash",
+ "spirv",
+ "thiserror",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -181,6 +679,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -199,6 +760,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +844,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +869,66 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustversion"
@@ -227,6 +941,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -283,16 +1003,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "spark-internal-rs"
+name = "space"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ab9701ae895386d13db622abf411989deff7109b13b46b6173bb4ce5c1d123"
+dependencies = [
+ "doc-comment",
+ "num-traits",
+]
+
+[[package]]
+name = "spark-lib"
 version = "0.1.0"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
+ "anyhow",
+ "glam",
+ "half",
+ "hnsw",
+ "image",
+ "itertools",
+ "miniz_oxide",
+ "ordered-float",
+ "rand_pcg",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "space",
+ "zip",
+]
+
+[[package]]
+name = "spark-rs"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "half",
+ "js-sys",
+ "serde-wasm-bindgen",
+ "spark-lib",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "spark-worker-rs"
+version = "0.1.0"
+dependencies = [
+ "ahash 0.8.12",
  "anyhow",
  "console_error_panic_hook",
  "glam",
@@ -309,18 +1093,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "spark-lib"
-version = "0.1.0"
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "ahash",
- "anyhow",
- "glam",
- "half",
- "miniz_oxide",
- "ordered-float",
- "serde",
- "smallvec",
+ "bitflags",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -334,6 +1119,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,10 +1157,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "version_check"
@@ -362,35 +1188,32 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
+name = "wasm-bindgen-futures"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -398,35 +1221,348 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wayland-sys"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "wgpu"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
@@ -446,4 +1582,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,12 @@ wasm-bindgen = "0.2.100"
 web-sys = { version = "0.3.77", features = ["console"] }
 zip = { version = "7.0.0", default-features = false, features = ["deflate"] }
 image = { version = "0.25.9", default-features = false, features = ["png", "webp"] }
+hnsw = "0.11.0"
+rand_pcg = "0.3.1"
+space = { version = "0.17.0", default-features = false, features = ["alloc"] }
+wgpu = "29"
+pollster = "0.4.0"
+bytemuck = { version = "1.25.0", features = ["derive"] }
 
 [profile.release]
 opt-level = 3

--- a/rust/build-lod/Cargo.toml
+++ b/rust/build-lod/Cargo.toml
@@ -11,3 +11,6 @@ repository.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true
 spark-lib = { path = "../spark-lib" }
+wgpu.workspace = true
+pollster.workspace = true
+bytemuck.workspace = true

--- a/rust/build-lod/src/gpu_sh_clustering.rs
+++ b/rust/build-lod/src/gpu_sh_clustering.rs
@@ -1,0 +1,342 @@
+use std::borrow::Cow;
+ 
+use bytemuck::{Pod, Zeroable};
+use wgpu::util::DeviceExt;
+
+use spark_lib::sh_clustering::FindNearestClusters;
+
+const WORKGROUP_SIZE: u32 = 64;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, Default)]
+struct Params {
+    num_points: u32,
+    num_clusters: u32,
+    dims: u32,
+    _pad: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, Debug, Default)]
+struct Out {
+    best_index: u32,
+    best_dist2: f32,
+}
+
+pub struct GpuFindNearestClusters {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    pipeline: wgpu::ComputePipeline,
+    bind_group: wgpu::BindGroup,
+    points_buf: wgpu::Buffer,
+    clusters_buf: wgpu::Buffer,
+    out_buf: wgpu::Buffer,
+    readback_buf: wgpu::Buffer,
+    params_buf: wgpu::Buffer,
+    num_clusters: usize,
+}
+
+impl GpuFindNearestClusters {
+    async fn try_new(max_dims: usize, max_clusters: usize, max_splats: usize) -> anyhow::Result<Self> {
+        // return Err(anyhow::anyhow!("GPU SH clustering disabled"));
+
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions::default())
+            .await?;
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::default(),
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                trace: wgpu::Trace::default(),
+            })
+            .await?;
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(SHADER)),
+        });
+
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bgl"),
+            entries: &[
+                storage_layout(0, true),  // points
+                storage_layout(1, true),  // clusters
+                storage_layout(2, false), // out
+                uniform_layout(3),        // params
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("pipeline layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            cache: None,
+        });
+
+        let points_bytes = (max_splats * max_dims * std::mem::size_of::<f32>()) as u64;
+        let clusters_bytes = (max_clusters * max_dims * std::mem::size_of::<f32>()) as u64;
+        let out_bytes = (max_splats * std::mem::size_of::<Out>()) as u64;
+
+        let points_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("points"),
+            size: points_bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let clusters_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("clusters"),
+            size: clusters_bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let out_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("out"),
+            size: out_bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+
+        let readback_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("readback"),
+            size: out_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let params_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("params"),
+            contents: bytemuck::bytes_of(&Params::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("bind group"),
+            layout: &bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: points_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: clusters_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: out_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: params_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        println!("GPU SH clustering initialized");
+
+        Ok(Self {
+            device,
+            queue,
+            pipeline,
+            bind_group,
+            points_buf,
+            clusters_buf,
+            out_buf,
+            readback_buf,
+            params_buf,
+            num_clusters: 0,
+        })
+    }
+}
+
+impl FindNearestClusters for GpuFindNearestClusters {
+    fn create_fnc(max_dims: usize, max_clusters: usize, max_splats: usize) -> anyhow::Result<Self> {
+        pollster::block_on(Self::try_new(max_dims, max_clusters, max_splats))
+    }
+
+    fn set_clusters(&mut self, dims: usize, clusters: &[f32]) -> anyhow::Result<()> {
+        let num_clusters = clusters.len() / dims;
+        assert_eq!(num_clusters * dims, clusters.len());
+        self.num_clusters = num_clusters;
+
+        self.queue.write_buffer(&self.clusters_buf, 0, bytemuck::cast_slice(clusters));
+
+        Ok(())
+    }
+    
+    fn find_nearest_clusters(&mut self, dims: usize, splats: &[f32]) -> anyhow::Result<Vec<(u32, f32)>> {
+        let num_splats = splats.len() / dims;
+        assert_eq!(num_splats * dims, splats.len());
+
+        self.queue.write_buffer(&self.points_buf, 0, bytemuck::cast_slice(splats));
+
+        let params = Params {
+            num_points: num_splats as u32,
+            num_clusters: self.num_clusters as u32,
+            dims: dims as u32,
+            _pad: 0,
+        };
+        self.queue.write_buffer(&self.params_buf, 0, bytemuck::bytes_of(&params));
+
+        let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("encoder") });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &self.bind_group, &[]);
+            let groups = num_splats.div_ceil(WORKGROUP_SIZE as usize);
+            pass.dispatch_workgroups(groups as u32, 1, 1);
+        }
+
+        let out_bytes = (num_splats * std::mem::size_of::<Out>()) as u64;
+        encoder.copy_buffer_to_buffer(&self.out_buf, 0, &self.readback_buf, 0, out_bytes);
+        self.queue.submit(Some(encoder.finish()));
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let slice = self.readback_buf.slice(0..out_bytes);
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = tx.send(result);
+        });
+
+        let _ = self.device.poll(wgpu::PollType::Wait { submission_index: None, timeout: None });
+        rx.recv().unwrap().unwrap();
+
+        let data = slice.get_mapped_range();
+        let data_cast: &[Out] = bytemuck::cast_slice(&data);
+
+        let mut out = Vec::with_capacity(num_splats);
+        for i in 0..num_splats {
+            out.push((data_cast[i].best_index, data_cast[i].best_dist2));
+        }
+
+        drop(data);
+        self.readback_buf.unmap();
+
+        Ok(out)
+    }
+}
+
+fn storage_layout(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+fn uniform_layout(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+const SHADER: &str = r#"
+struct Params {
+    num_points: u32,
+    num_clusters: u32,
+    dims: u32,
+    _pad: u32,
+};
+
+struct Out {
+    best_index: u32,
+    best_dist2: f32,
+};
+
+@group(0) @binding(0) var<storage, read> points: array<f32>;
+@group(0) @binding(1) var<storage, read> clusters: array<f32>;
+@group(0) @binding(2) var<storage, read_write> out_buf: array<Out>;
+@group(0) @binding(3) var<uniform> params: Params;
+
+const MAX_DIMS: u32 = 45u;
+const TILE_CLUSTERS: u32 = 64u;
+
+var<workgroup> cluster_tile: array<f32, TILE_CLUSTERS * MAX_DIMS>;
+
+@compute @workgroup_size(64)
+fn main(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+    @builtin(local_invocation_id) lid: vec3<u32>,
+) {
+    let point_idx = gid.x;
+    let lane = lid.x;
+    let point_active = point_idx < params.num_points;
+
+    var p: array<f32, MAX_DIMS>;
+    if (point_active) {
+        let point_base = point_idx * params.dims;
+        for (var d: u32 = 0u; d < params.dims; d = d + 1u) {
+            p[d] = points[point_base + d];
+        }
+    }
+
+    var best_index: u32 = 0u;
+    var best_dist2: f32 = 3.402823e38;
+
+    let num_tiles = (params.num_clusters + TILE_CLUSTERS - 1u) / TILE_CLUSTERS;
+
+    for (var tile: u32 = 0u; tile < num_tiles; tile = tile + 1u) {
+        let base = tile * TILE_CLUSTERS;
+        let cluster_idx = base + lane;
+
+        if (cluster_idx < params.num_clusters) {
+            let cluster_base = cluster_idx * params.dims;
+            for (var d: u32 = 0u; d < params.dims; d = d + 1u) {
+                cluster_tile[lane * MAX_DIMS + d] = clusters[cluster_base + d];
+            }
+        }
+        workgroupBarrier();
+
+        if (point_active) {
+            let tile_count = min(TILE_CLUSTERS, params.num_clusters - base);
+            for (var j: u32 = 0u; j < tile_count; j = j + 1u) {
+                var dist2: f32 = 0.0;
+                for (var d: u32 = 0u; d < params.dims; d = d + 1u) {
+                    let t = p[d] - cluster_tile[j * MAX_DIMS + d];
+                    dist2 = dist2 + t * t;
+                }
+                let k = base + j;
+                if (dist2 < best_dist2) {
+                    best_dist2 = dist2;
+                    best_index = k;
+                }
+            }
+        }
+        workgroupBarrier();
+    }
+
+    if (point_active) {
+        out_buf[point_idx].best_index = best_index;
+        out_buf[point_idx].best_dist2 = best_dist2;
+    }
+}
+"#;

--- a/rust/build-lod/src/main.rs
+++ b/rust/build-lod/src/main.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 
-use spark_lib::chunk_tree;
+use spark_lib::{chunk_tree, sh_clustering};
 use spark_lib::decoder::{SplatEncoding, SplatGetter, SplatReceiver};
 use spark_lib::rad::RadEncoder;
 use spark_lib::{
@@ -14,7 +14,9 @@ use spark_lib::{
     spz::SpzEncoder,
 };
 
-const INFLATE_SCALE: bool = false;
+use crate::gpu_sh_clustering::GpuFindNearestClusters;
+
+mod gpu_sh_clustering;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 enum BuildLodOutput {
@@ -23,6 +25,12 @@ enum BuildLodOutput {
     RadChunked,
     Spz,
     SpzChunked,
+}
+
+impl BuildLodOutput {
+    fn is_rad(&self) -> bool {
+        matches!(self, BuildLodOutput::Rad | BuildLodOutput::RadChunked)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -36,8 +44,8 @@ enum BuildLodTsplat {
 enum BuildLodMethod {
     TinyLod { lod_base: f32 },
     BhattLod { lod_base: f32 },
-    #[default]
     Quick,
+    #[default]
     Quality,
 }
 
@@ -53,6 +61,9 @@ struct BuildLodOptions {
     max_box: Option<[f32; 3]>,
     within_dist: Option<([f32; 3], f32)>,
     skip_validate: bool,
+    inflate: bool,
+    cluster_sh: Option<usize>,
+    cluster_sh_cpu: bool,
 }
 
 fn read_file_chunks(filename: &str, decoder: &mut impl ChunkReceiver) -> anyhow::Result<()> {
@@ -228,11 +239,51 @@ fn process_file_lod_tsplat<TS: SplatReceiver + TsplatArray + SplatGetter>(filena
     let chunk_duration = start_time.elapsed();
     description.insert("chunk_duration".to_string(), serde_json::Number::from_f64(chunk_duration.as_secs_f64()).into());
 
+    let num_sh = TsplatArray::max_sh_degree(&splats).min(options.max_sh.unwrap_or(3));
+    let mut sh_clusters = None;
+    if let Some(num_iterations) = options.cluster_sh {
+        if num_sh > 0 {
+            let num_clusters = splats.len().min(65536);
+            let start_time = std::time::Instant::now();
+
+            if !options.cluster_sh_cpu {
+                match sh_clustering::compute_sh_clusters::<GpuFindNearestClusters, _>(
+                    &splats,
+                    num_sh,
+                    num_clusters,
+                    num_iterations,
+                    |s| println!("{}", s),
+                ) {
+                    Ok(clusters) => {
+                        sh_clusters = Some(clusters);
+                    },
+                    Err(e) => {
+                        println!("Error GPU SH clustering: {}", e);
+                    },
+                }
+            }
+
+            if sh_clusters.is_none() {
+                let clusters = sh_clustering::compute_sh_clusters::<sh_clustering::CpuFindNearestClusters, _>(
+                    &splats,
+                    num_sh,
+                    num_clusters,
+                    num_iterations,
+                    |s| println!("{}", s),
+                ).unwrap();
+                sh_clusters = Some(clusters);
+            }
+            
+            let sh_cluster_duration = start_time.elapsed();
+            description.insert("sh_cluster_duration".to_string(), serde_json::Number::from_f64(sh_cluster_duration.as_secs_f64()).into());
+        }
+    }
+
     for i in 0..splats.len() {
         let mut splat = splats.get_mut(i);
         
         if splat.opacity() > 1.0 {
-            if !INFLATE_SCALE {
+            if !options.inflate {
                 let d = splat.lod_opacity();
                 // // Map 1..5 LOD-encoded opacity to 1..2 opacity
                 splat.set_opacity((0.25 * (d - 1.0) + 1.0).clamp(1.0, 2.0));
@@ -243,21 +294,27 @@ fn process_file_lod_tsplat<TS: SplatReceiver + TsplatArray + SplatGetter>(filena
             }
         }
     }
-    if INFLATE_SCALE {
+
+    if options.inflate {
         description.insert("inflate_scale".to_string(), serde_json::Value::Bool(true));
     }
 
     match options.output {
         BuildLodOutput::Rad | BuildLodOutput::RadChunked => {
             let mut encoder = RadEncoder::new(splats);
+            if let Some(sh_clusters) = sh_clusters {
+                encoder = encoder.with_sh_clusters(sh_clusters);
+            }
+
             let input_encoding = serde_json::json!({
-                    "center": encoder.center_encoding,
-                    "alpha": encoder.alpha_encoding,
-                    "rgb": encoder.rgb_encoding,
-                    "scales": encoder.scales_encoding,
-                    "orientation": encoder.orientation_encoding,
-                    "sh": encoder.sh_encoding,
-                    "encoding": encoder.encoding,
+                "center": encoder.center_encoding,
+                "alpha": encoder.alpha_encoding,
+                "rgb": encoder.rgb_encoding,
+                "scales": encoder.scales_encoding,
+                "orientation": encoder.orientation_encoding,
+                "sh": encoder.sh_encoding,
+                "encoding": encoder.encoding,
+                "sh_label": encoder.sh_label_encoding,
             });
             description.insert("input_encoding".to_string(), input_encoding);
 
@@ -270,6 +327,7 @@ fn process_file_lod_tsplat<TS: SplatReceiver + TsplatArray + SplatGetter>(filena
                 "orientation": encoder.orientation_encoding,
                 "sh": encoder.sh_encoding,
                 "encoding": encoder.encoding,
+                "sh_label": encoder.sh_label_encoding,
             });
             description.insert("resolved_encoding".to_string(), resolved_encoding);
 
@@ -332,7 +390,7 @@ fn show_usage_exit() {
     eprintln!("Usage: build-lod");
     eprintln!("  [--unlod]                                       // Remove LoD nodes with children from file");
     eprintln!("  [--csplat] [--gsplat]                           // Use compact (csplat) or higher-precision (default gsplat) splat encoding");
-    eprintln!("  [--quick] [--quality]                           // Use quick (tiny-lod) or quality (bhatt-lod) LoD method (default quick)");
+    eprintln!("  [--quick] [--quality]                           // Use quick (tiny-lod) or quality (bhatt-lod) LoD method (default quality)");
     eprintln!("  [--tiny-lod[=<base>]] [--bhatt-lod[=<base>]]    // Use tiny-lod (default base 1.5) or bhatt-lod (default base 1.75) LoD method");
     eprintln!("  [--max-sh=<max-sh>]                             // Set maximum SH degree (default 3)");
     eprintln!("  [--rad] [--rad-chunked] [--spz] [--spz-chunked] // Output RAD (+chunked) or SPZ (+chunked) output files");
@@ -340,6 +398,9 @@ fn show_usage_exit() {
     eprintln!("  [--max-box=<x>,<y>,<z>]                         // Crop input file to maximum bounding coord");
     eprintln!("  [--within-dist=<x>,<y>,<z>,<radius>]            // Crop input file to within radius of a point");
     eprintln!("  [--skip-validate]                               // Skip validation of input file");
+    eprintln!("  [--inflate]                                     // Inflate scales to output normal splat opacity 0..1");
+    eprintln!("  [--cluster-sh[=<iterations>]]                   // Cluster SH coefficients into <=64K codebook (default 10 iterations)");
+    eprintln!("  [--cluster-sh-cpu[=<iterations>]]               // Cluster SH coefficients using CPU");
     eprintln!("  <file.ply|file.spz|file.compressed.ply|file.splat|file.ksplat|file.sog|file.rad> [...] // Multiple input files and wildcards allowed");
     std::process::exit(1);
 }
@@ -482,11 +543,58 @@ fn main() {
             println!("Using --skip-validate: Skip validation of input file");
             continue;
         }
+        if arg == "--inflate" {
+            options.inflate = true;
+            println!("Using --inflate: Inflate scales to output normal splat opacity 0..1");
+            continue;
+        }
+        if let Some(rest) = arg.strip_prefix("--cluster-sh-cpu") {
+            options.cluster_sh_cpu = true;
+            if let Some(rest) = rest.strip_prefix("=") {
+                match rest.parse::<usize>() {
+                    Ok(v) => {
+                        options.cluster_sh = Some(v);
+                        println!("Using --cluster-sh-cpu with {} iterations", v);
+                    }
+                    Err(_) => {
+                        eprintln!("Invalid --cluster-sh-cpu iterations: {}", rest);
+                        show_usage_exit();
+                    }
+                }
+            } else {
+                options.cluster_sh = Some(10);
+                println!("Using --cluster-sh-cpu with default 10 iterations");
+            }
+            continue;
+        }
+        if let Some(rest) = arg.strip_prefix("--cluster-sh") {
+            if let Some(rest) = rest.strip_prefix("=") {
+                match rest.parse::<usize>() {
+                    Ok(v) => {
+                        options.cluster_sh = Some(v);
+                        println!("Using --cluster-sh with {} iterations", v);
+                    }
+                    Err(_) => {
+                        eprintln!("Invalid --cluster-sh iterations: {}", rest);
+                        show_usage_exit();
+                    }
+                }
+            } else {
+                options.cluster_sh = Some(10);
+                println!("Using --cluster-sh with default 10 iterations");
+            }
+            continue;
+        }
         if arg.starts_with("--") {
             eprintln!("Unknown option: {}", arg);
             show_usage_exit();
         }
         filenames.push(arg);
+    }
+
+    if options.cluster_sh.is_some() && !options.output.is_rad() {
+        eprintln!("--cluster-sh is only supported for RAD output");
+        show_usage_exit();
     }
 
     if filenames.is_empty() {

--- a/rust/spark-lib/Cargo.toml
+++ b/rust/spark-lib/Cargo.toml
@@ -20,3 +20,6 @@ itertools.workspace = true
 serde_json.workspace = true
 zip.workspace = true
 image.workspace = true
+hnsw.workspace = true
+rand_pcg.workspace = true
+space.workspace = true

--- a/rust/spark-lib/src/bhatt_lod.rs
+++ b/rust/spark-lib/src/bhatt_lod.rs
@@ -1,7 +1,7 @@
 use std::collections::BinaryHeap;
 
 use ahash::AHashMap;
-use glam::IVec3;
+use glam::I64Vec3;
 use ordered_float::OrderedFloat;
 use smallvec::{SmallVec, smallvec};
 
@@ -32,7 +32,7 @@ pub fn compute_lod_tree<TA: TsplatArray>(splats: &mut TA, lod_base: f32, logger:
     let mut level = level_min;
     let mut frontier = 0;
     let mut active = BinaryHeap::new();
-    let mut cells = AHashMap::<[i32; 3], SmallVec<[usize; 8]>>::new();
+    let mut cells = AHashMap::<I64Vec3, SmallVec<[usize; 8]>>::new();
 
     loop {
         let step = MERGE_BASE.powf(level as f32);
@@ -55,11 +55,11 @@ pub fn compute_lod_tree<TA: TsplatArray>(splats: &mut TA, lod_base: f32, logger:
         logger(&format!("Level: {}, step: {}, frontier: {} / {}, # active: {}, # splats: {}", level, step, frontier, initial_len, active.len(), splats.len()));
 
         cells.clear();
-        let mut grid_min_max = [IVec3::splat(i32::MAX), IVec3::splat(i32::MIN)];
+        let mut grid_min_max = [I64Vec3::splat(i64::MAX), I64Vec3::splat(i64::MIN)];
 
         for &(OrderedFloat(_neg_size), index) in active.iter() {
             let splat = splats.get(index);
-            let grid = splat.grid_i32(step);
+            let grid = splat.grid(step);
             cells.entry(grid).or_default().push(index);
         }
 
@@ -70,20 +70,21 @@ pub fn compute_lod_tree<TA: TsplatArray>(splats: &mut TA, lod_base: f32, logger:
                 continue;
             }
 
-            let grid = splats.get(index).grid_i32(step);
-            grid_min_max = [grid_min_max[0].min(IVec3::from_array(grid)), grid_min_max[1].max(IVec3::from_array(grid))];
+            let grid = splats.get(index).grid(step);
+            grid_min_max = [grid_min_max[0].min(grid), grid_min_max[1].max(grid)];
 
-            let mut best = (usize::MAX, -f32::INFINITY, [i32::MAX, i32::MAX, i32::MAX]);
+            let mut best = (usize::MAX, -f32::INFINITY, I64Vec3::splat(i64::MAX));
 
             for z in (grid[2] - 1)..=(grid[2] + 1) {
                 for y in (grid[1] - 1)..=(grid[1] + 1) {
                     for x in (grid[0] - 1)..=(grid[0] + 1) {
-                        if let Some(neighbors) = cells.get(&[x, y, z]) {
+                        let g = I64Vec3::new(x, y, z);
+                        if let Some(neighbors) = cells.get(&g) {
                             for &neighbor in neighbors.iter() {
                                 if is_active[neighbor] && neighbor != index {
                                     let metric = splats.similarity(index, neighbor);
                                     if metric > best.1 {
-                                        best = (neighbor, metric, [x, y, z]);
+                                        best = (neighbor, metric, g);
                                     }
                                 }
                             }
@@ -113,7 +114,7 @@ pub fn compute_lod_tree<TA: TsplatArray>(splats: &mut TA, lod_base: f32, logger:
                 if feature_size > step {
                     next_active.push((OrderedFloat(-feature_size), merged));
                 } else {
-                    let merged_grid = splats.get(merged).grid_i32(step);
+                    let merged_grid = splats.get(merged).grid(step);
                     cells.entry(merged_grid).or_default().push(merged);
 
                     active.push((OrderedFloat(-feature_size), merged));
@@ -225,7 +226,7 @@ pub fn compute_lod_tree<TA: TsplatArray>(splats: &mut TA, lod_base: f32, logger:
     let mut frontier = vec![root_index];
 
     loop {
-        logger(&format!("Chunking from limit_size={}, # frontier={}", limit_size, frontier.len()));
+        logger(&format!("Pruning from limit_size={}, # frontier={}", limit_size, frontier.len()));
         let mut next_frontier = Vec::new();
         for index in frontier.drain(..) {
             recurse_indices(splats, index, &to_output, &mut indices, limit_size, &mut next_frontier);

--- a/rust/spark-lib/src/csplat.rs
+++ b/rust/spark-lib/src/csplat.rs
@@ -582,33 +582,39 @@ impl SplatReceiver for CsplatArray {
     }
 
     fn set_sh1(&mut self, base: usize, count: usize, sh1: &[f32]) {
+        let SplatEncoding { sh1_max, .. } = *self.encoding.as_ref().unwrap_or(&SplatEncoding::default());
+        let rescale = 127.0 / sh1_max;
         if self.max_sh_degree >= 1 {
             for i in 0..count {
                 let i9 = i * 9;
                 for k in 0..9 {
-                    self.sh1[base + i][k] = (sh1[i9 + k] * (127.0 / 1.0)).clamp(-127.0, 127.0).round() as i8;
+                    self.sh1[base + i][k] = (sh1[i9 + k] * rescale).clamp(-127.0, 127.0).round() as i8;
                 }
             }
         }
     }
 
     fn set_sh2(&mut self, base: usize, count: usize, sh2: &[f32]) {
+        let SplatEncoding { sh2_max, .. } = *self.encoding.as_ref().unwrap_or(&SplatEncoding::default());
+        let rescale = 127.0 / sh2_max;
         if self.max_sh_degree >= 2 {
             for i in 0..count {
                 let i15 = i * 15;
                 for k in 0..15 {
-                    self.sh2[base + i][k] = (sh2[i15 + k] * (127.0 / 1.0)).clamp(-127.0, 127.0).round() as i8;
+                    self.sh2[base + i][k] = (sh2[i15 + k] * rescale).clamp(-127.0, 127.0).round() as i8;
                 }
             }
         }
     }
 
     fn set_sh3(&mut self, base: usize, count: usize, sh3: &[f32]) {
+        let SplatEncoding { sh3_max, .. } = *self.encoding.as_ref().unwrap_or(&SplatEncoding::default());
+        let rescale = 127.0 / sh3_max;
         if self.max_sh_degree >= 3 {
             for i in 0..count {
                 let i21 = i * 21;
                 for k in 0..21 {
-                    self.sh3[base + i][k] = (sh3[i21 + k] * (127.0 / 1.0)).clamp(-127.0, 127.0).round() as i8;
+                    self.sh3[base + i][k] = (sh3[i21 + k] * rescale).clamp(-127.0, 127.0).round() as i8;
                 }
             }
         }

--- a/rust/spark-lib/src/decoder.rs
+++ b/rust/spark-lib/src/decoder.rs
@@ -160,6 +160,11 @@ pub trait SplatReceiver: 'static {
     fn set_sh2(&mut self, base: usize, count: usize, sh2: &[f32]) {}
     fn set_sh3(&mut self, base: usize, count: usize, sh3: &[f32]) {}
 
+    fn set_sh1_codes(&mut self, base: usize, count: usize, sh1_codes: &[f32]) {}
+    fn set_sh2_codes(&mut self, base: usize, count: usize, sh2_codes: &[f32]) {}
+    fn set_sh3_codes(&mut self, base: usize, count: usize, sh3_codes: &[f32]) {}
+    fn set_sh_labels(&mut self, base: usize, count: usize, sh_labels: &[u32]) {}
+
     fn set_child_count(&mut self, base: usize, count: usize, child_count: &[u16]) {}
     fn set_child_start(&mut self, base: usize, count: usize, child_start: &[usize]) {}
 }

--- a/rust/spark-lib/src/lib.rs
+++ b/rust/spark-lib/src/lib.rs
@@ -16,6 +16,7 @@ pub mod decoder;
 pub mod splat_encode;
 pub mod ordering;
 pub mod chunk_tree;
+pub mod sh_clustering;
 
 #[cfg(test)]
 mod tests {

--- a/rust/spark-lib/src/ply.rs
+++ b/rust/spark-lib/src/ply.rs
@@ -1107,13 +1107,25 @@ fn f_rest_name(max_sh_degree: usize, degree: usize, k: usize, d: usize) -> Strin
 pub struct PlyEncoder<T: SplatGetter> {
     getter: T,
     max_sh_out: Option<u8>,
+    compatibility: bool,
 }
 
 impl<T: SplatGetter> PlyEncoder<T> {
-    pub fn new(getter: T) -> Self { Self { getter, max_sh_out: None } }
+    pub fn new(getter: T) -> Self {
+        Self {
+            getter,
+            max_sh_out: None,
+            compatibility: false,
+        }
+    }
 
     pub fn with_max_sh(mut self, max_sh: u8) -> Self {
         self.max_sh_out = Some(max_sh.min(3));
+        self
+    }
+
+    pub fn with_compatibility(mut self, compatibility: bool) -> Self {
+        self.compatibility = compatibility;
         self
     }
 
@@ -1130,6 +1142,11 @@ impl<T: SplatGetter> PlyEncoder<T> {
         header.push_str("property float x\n");
         header.push_str("property float y\n");
         header.push_str("property float z\n");
+        if self.compatibility {
+            header.push_str("property float nx\n");
+            header.push_str("property float ny\n");
+            header.push_str("property float nz\n");
+        }
         header.push_str("property float scale_0\n");
         header.push_str("property float scale_1\n");
         header.push_str("property float scale_2\n");
@@ -1196,6 +1213,12 @@ impl<T: SplatGetter> PlyEncoder<T> {
                 write_f32_le(centers[i3 + 0])?;
                 write_f32_le(centers[i3 + 1])?;
                 write_f32_le(centers[i3 + 2])?;
+
+                if self.compatibility {
+                    write_f32_le(0.0)?;
+                    write_f32_le(0.0)?;
+                    write_f32_le(0.0)?;
+                }
 
                 // ln scales
                 write_f32_le(scales[i3 + 0].ln())?;

--- a/rust/spark-lib/src/rad.rs
+++ b/rust/spark-lib/src/rad.rs
@@ -18,6 +18,7 @@ use miniz_oxide::inflate::decompress_to_vec;
 // }
 
 use crate::decoder::{ChunkReceiver, SetSplatEncoding, SplatEncoding, SplatGetter, SplatInit, SplatReceiver};
+use crate::sh_clustering::ShClusters;
 use crate::splat_encode::{self, decode_scale8, encode_scale8_zero};
 
 pub const RAD_MAGIC: u32 = 0x30444152; // 'RAD0'
@@ -36,6 +37,8 @@ pub struct RadEncoder<T: SplatGetter> {
     pub scales_encoding: RadScalesEncoding,
     pub orientation_encoding: RadOrientationEncoding,
     pub sh_encoding: RadShEncoding,
+    pub sh_label_encoding: RadShLabelEncoding,
+    pub sh_clusters: Option<ShClusters>,
     pub comment: Option<String>,
 }
 
@@ -96,6 +99,14 @@ pub enum RadShEncoding {
     S8Delta,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RadShLabelEncoding {
+    #[default]
+    Auto,
+    U16,
+    U32,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct RadChunkRange {
     offset: u64,
@@ -125,6 +136,8 @@ pub struct RadMeta {
     chunks: Vec<RadChunkRange>,
     #[serde(rename = "splatEncoding", skip_serializing_if = "Option::is_none")]
     splat_encoding: Option<SetSplatEncoding>,
+    #[serde(rename = "shCodeCount", skip_serializing_if = "Option::is_none")]
+    sh_code_count: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     comment: Option<String>,
 }
@@ -188,6 +201,14 @@ pub enum RadChunkPropertyName {
     ChildCount,
     #[serde(rename = "child_start")]
     ChildStart,
+    #[serde(rename = "sh1_code")]
+    Sh1Code,
+    #[serde(rename = "sh2_code")]
+    Sh2Code,
+    #[serde(rename = "sh3_code")]
+    Sh3Code,
+    #[serde(rename = "sh_label")]
+    ShLabel,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -239,6 +260,8 @@ impl<T: SplatGetter> RadEncoder<T> {
             scales_encoding: RadScalesEncoding::default(),
             orientation_encoding: RadOrientationEncoding::default(),
             sh_encoding: RadShEncoding::default(),
+            sh_label_encoding: RadShLabelEncoding::default(),
+            sh_clusters: None,
             comment: None,
         }
     }
@@ -458,6 +481,19 @@ impl<T: SplatGetter> RadEncoder<T> {
         self.sh_encoding = RadShEncoding::S8;
     }
 
+    pub fn resolve_sh_label_encoding(&mut self) {
+        if self.sh_label_encoding != RadShLabelEncoding::Auto {
+            return;
+        }
+        if let Some(clusters) = self.sh_clusters.as_ref() {
+            if clusters.num_clusters > 65536 {
+                self.sh_label_encoding = RadShLabelEncoding::U32;
+            } else {
+                self.sh_label_encoding = RadShLabelEncoding::U16;
+            }
+        }
+    }
+
     pub fn resolve_encoding(&mut self) {
         self.resolve_center_encoding();
         self.resolve_alpha_encoding();
@@ -465,6 +501,12 @@ impl<T: SplatGetter> RadEncoder<T> {
         self.resolve_scales_encoding();
         self.resolve_orientation_encoding();
         self.resolve_sh_encoding();
+        self.resolve_sh_label_encoding();
+    }
+
+    pub fn with_sh_clusters(mut self, clusters: ShClusters) -> Self {
+        self.sh_clusters = Some(clusters);
+        self
     }
 
     pub fn encode<W: Write>(&mut self, writer: &mut W) -> anyhow::Result<()> {
@@ -531,6 +573,7 @@ impl<T: SplatGetter> RadEncoder<T> {
             all_chunk_bytes: all_chunk_bytes,
             chunks: chunk_ranges,
             splat_encoding: None,
+            sh_code_count: self.sh_clusters.as_ref().map(|c| c.num_clusters as u32),
             comment: self.comment.clone(),
         };
         if let Some(mut encoding) = self.encoding.clone().or_else(|| self.getter.get_encoding()) {
@@ -690,20 +733,42 @@ impl<T: SplatGetter> RadEncoder<T> {
 
     fn encode_chunk_sh(&mut self, base: usize, count: usize, buffer: &mut Vec<f32>, encoding: &SplatEncoding, property: RadChunkPropertyName) -> (RadChunkProperty, Vec<u8>) {
         let (elements, sh_max) = match property {
-            RadChunkPropertyName::Sh1 => (9, encoding.sh1_max),
-            RadChunkPropertyName::Sh2 => (15, encoding.sh2_max),
-            RadChunkPropertyName::Sh3 => (21, encoding.sh3_max),
+            RadChunkPropertyName::Sh1 | RadChunkPropertyName::Sh1Code => (9, encoding.sh1_max),
+            RadChunkPropertyName::Sh2 | RadChunkPropertyName::Sh2Code => (15, encoding.sh2_max),
+            RadChunkPropertyName::Sh3 | RadChunkPropertyName::Sh3Code => (21, encoding.sh3_max),
             _ => unreachable!(),
         };
         if buffer.len() < count * elements {
             buffer.resize(count * elements, 0.0);
         }
-        match property {
-            RadChunkPropertyName::Sh1 => self.getter.get_sh1(base, count, &mut buffer[..count * elements]),
-            RadChunkPropertyName::Sh2 => self.getter.get_sh2(base, count, &mut buffer[..count * elements]),
-            RadChunkPropertyName::Sh3 => self.getter.get_sh3(base, count, &mut buffer[..count * elements]),
-            _ => unreachable!(),
-        };
+
+        if let Some(clusters) = self.sh_clusters.as_ref() {
+            match property {
+                RadChunkPropertyName::Sh1Code => {
+                    for (i, &value) in clusters.sh1.iter().flatten().enumerate() {
+                        buffer[i] = value;
+                    }
+                },
+                RadChunkPropertyName::Sh2Code => {
+                    for (i, &value) in clusters.sh2.iter().flatten().enumerate() {
+                        buffer[i] = value;
+                    }
+                },
+                RadChunkPropertyName::Sh3Code => {
+                    for (i, &value) in clusters.sh3.iter().flatten().enumerate() {
+                        buffer[i] = value;
+                    }
+                },
+                _ => unreachable!(),
+            }
+        } else {
+            match property {
+                RadChunkPropertyName::Sh1 => self.getter.get_sh1(base, count, &mut buffer[..count * elements]),
+                RadChunkPropertyName::Sh2 => self.getter.get_sh2(base, count, &mut buffer[..count * elements]),
+                RadChunkPropertyName::Sh3 => self.getter.get_sh3(base, count, &mut buffer[..count * elements]),
+                _ => unreachable!(),
+            }    
+        }
 
         let (encoding, bytes, min, max) = match self.sh_encoding {
             RadShEncoding::F32 => (RadChunkPropertyEncoding::F32, encode_f32(&buffer, elements, count), None, None),
@@ -718,6 +783,32 @@ impl<T: SplatGetter> RadEncoder<T> {
             compression: Some(RadChunkPropertyCompression::Gz),
             min,
             max,
+            ..Default::default()
+        };
+        (meta, compress_to_vec(&bytes, GZ_LEVEL))
+    }
+
+    fn encode_chunk_sh_label(&mut self, base: usize, count: usize, buffer: &mut Vec<usize>) -> (RadChunkProperty, Vec<u8>) {
+        let Some(clusters) = self.sh_clusters.as_ref() else {
+            panic!("sh_clusters not set");
+        };
+
+        if buffer.len() < count {
+            buffer.resize(count, 0);
+        }
+        for i in 0..count {
+            buffer[i] = clusters.labels[base + i];
+        }
+
+        let (encoding, bytes) = match self.sh_label_encoding {
+            RadShLabelEncoding::U16 => (RadChunkPropertyEncoding::U16, encode_usize_as_u16(&buffer, 1, count)),
+            RadShLabelEncoding::U32 => (RadChunkPropertyEncoding::U32, encode_usize_as_u32(&buffer, 1, count)),
+            _ => unreachable!(),
+        };
+        let meta = RadChunkProperty {
+            property: RadChunkPropertyName::ShLabel,
+            encoding,
+            compression: Some(RadChunkPropertyCompression::Gz),
             ..Default::default()
         };
         (meta, compress_to_vec(&bytes, GZ_LEVEL))
@@ -769,16 +860,32 @@ impl<T: SplatGetter> RadEncoder<T> {
             self.encode_chunk_orientation(base, count, buffer),
         ];
 
-        if max_sh >= 1 {
-            props.push(self.encode_chunk_sh(base, count, buffer, encoding, RadChunkPropertyName::Sh1));
-        };
-
-        if max_sh >= 2 {
-            props.push(self.encode_chunk_sh(base, count, buffer, encoding, RadChunkPropertyName::Sh2));
-        }
-
-        if max_sh >= 3 {
-            props.push(self.encode_chunk_sh(base, count, buffer, encoding, RadChunkPropertyName::Sh3));
+        let num_clusters = self.sh_clusters.as_ref().map(|c| c.num_clusters);
+        if let Some(num_clusters) = num_clusters {
+            if base == 0 {
+                if max_sh >= 1 {
+                    props.push(self.encode_chunk_sh(0, num_clusters, buffer, encoding, RadChunkPropertyName::Sh1Code));
+                }
+                if max_sh >= 2 {
+                    props.push(self.encode_chunk_sh(0, num_clusters, buffer, encoding, RadChunkPropertyName::Sh2Code));
+                }
+                if max_sh >= 3 {
+                    props.push(self.encode_chunk_sh(0, num_clusters, buffer, encoding, RadChunkPropertyName::Sh3Code));
+                }
+            }
+            if max_sh >= 1 {
+                props.push(self.encode_chunk_sh_label(base, count, buffer_usize));
+            }
+        } else {
+            if max_sh >= 1 {
+                props.push(self.encode_chunk_sh(base, count, buffer, encoding, RadChunkPropertyName::Sh1));
+            };
+            if max_sh >= 2 {
+                props.push(self.encode_chunk_sh(base, count, buffer, encoding, RadChunkPropertyName::Sh2));
+            }
+            if max_sh >= 3 {
+                props.push(self.encode_chunk_sh(base, count, buffer, encoding, RadChunkPropertyName::Sh3));
+            }
         }
 
         if self.getter.has_lod_tree() {
@@ -1150,7 +1257,47 @@ fn encode_u16(data: &[u16], dims: usize, count: usize) -> Vec<u8> {
 fn decode_u16(data: &[u8], dims: usize, count: usize) -> Vec<u16> {
     let mut result = Vec::with_capacity(dims * count);
     for i in 0..count {
-        result.push(u16::from_le_bytes([data[i * 2], data[i * 2 + 1]]));
+        let mut index = i * 2;
+        for _ in 0..dims {
+            result.push(u16::from_le_bytes([data[index], data[index + 1]]));
+            index += count * 2;
+        }
+    }
+    result
+}
+
+fn decode_u16_as_u32(data: &[u8], dims: usize, count: usize) -> Vec<u32> {
+    let mut result = Vec::with_capacity(dims * count);
+    for i in 0..count {
+        let mut index = i * 2;
+        for _ in 0..dims {
+            result.push(u16::from_le_bytes([data[index], data[index + 1]]) as u32);
+            index += count * 2;
+        }
+    }
+    result
+}
+
+fn encode_u32(data: &[u32], dims: usize, count: usize) -> Vec<u8> {
+    let mut result = Vec::with_capacity(4 * dims * count);
+    for d in 0..dims {
+        let mut index = d;
+        for _ in 0..count {
+            result.extend(data[index].to_le_bytes());
+            index += dims;
+        }
+    }
+    result
+}
+
+fn decode_u32(data: &[u8], dims: usize, count: usize) -> Vec<u32> {
+    let mut result = Vec::with_capacity(dims * count);
+    for i in 0..count {
+        let mut index = i * 4;
+        for _ in 0..dims {
+            result.push(u32::from_le_bytes([data[index], data[index + 1], data[index + 2], data[index + 3]]));
+            index += count * 4;
+        }
     }
     result
 }
@@ -1170,7 +1317,35 @@ fn encode_usize_as_u32(data: &[usize], dims: usize, count: usize) -> Vec<u8> {
 fn decode_u32_as_usize(data: &[u8], dims: usize, count: usize) -> Vec<usize> {
     let mut result = Vec::with_capacity(dims * count);
     for i in 0..count {
-        result.push(u32::from_le_bytes(data[i * 4..i * 4 + 4].try_into().unwrap()) as usize);
+        let mut index = i * 4;
+        for _ in 0..dims {
+            result.push(u32::from_le_bytes([data[index], data[index + 1], data[index + 2], data[index + 3]]) as usize);
+            index += count * 4;
+        }
+    }
+    result
+}
+
+fn encode_usize_as_u16(data: &[usize], dims: usize, count: usize) -> Vec<u8> {
+    let mut result = Vec::with_capacity(2 * dims * count);
+    for d in 0..dims {
+        let mut index = d;
+        for _ in 0..count {
+            result.extend((data[index] as u16).to_le_bytes());
+            index += dims;
+        }
+    }
+    result
+}
+
+fn decode_u16_as_usize(data: &[u8], dims: usize, count: usize) -> Vec<usize> {
+    let mut result = Vec::with_capacity(dims * count);
+    for i in 0..count {
+        let mut index = i * 2;
+        for _ in 0..dims {
+            result.push(u16::from_le_bytes([data[index], data[index + 1]]) as usize);
+            index += count * 2;
+        }
     }
     result
 }
@@ -1534,11 +1709,12 @@ impl<T: SplatReceiver> RadDecoder<T> {
                     };
                     self.splats.set_quat(self.base, self.count, &quaternions);
                 },
-                RadChunkPropertyName::Sh1 | RadChunkPropertyName::Sh2 | RadChunkPropertyName::Sh3 => {
+                RadChunkPropertyName::Sh1 | RadChunkPropertyName::Sh2 | RadChunkPropertyName::Sh3 |
+                RadChunkPropertyName::Sh1Code | RadChunkPropertyName::Sh2Code | RadChunkPropertyName::Sh3Code => {
                     let elements = match prop.property {
-                        RadChunkPropertyName::Sh1 => 9,
-                        RadChunkPropertyName::Sh2 => 15,
-                        RadChunkPropertyName::Sh3 => 21,
+                        RadChunkPropertyName::Sh1 | RadChunkPropertyName::Sh1Code => 9,
+                        RadChunkPropertyName::Sh2 | RadChunkPropertyName::Sh2Code => 15,
+                        RadChunkPropertyName::Sh3 | RadChunkPropertyName::Sh3Code => 21,
                         _ => unreachable!()
                     };
                     let shs = match prop.encoding {
@@ -1573,8 +1749,19 @@ impl<T: SplatReceiver> RadDecoder<T> {
                         RadChunkPropertyName::Sh1 => self.splats.set_sh1(self.base, self.count, &shs),
                         RadChunkPropertyName::Sh2 => self.splats.set_sh2(self.base, self.count, &shs),
                         RadChunkPropertyName::Sh3 => self.splats.set_sh3(self.base, self.count, &shs),
+                        RadChunkPropertyName::Sh1Code => self.splats.set_sh1_codes(self.base, self.count, &shs),
+                        RadChunkPropertyName::Sh2Code => self.splats.set_sh2_codes(self.base, self.count, &shs),
+                        RadChunkPropertyName::Sh3Code => self.splats.set_sh3_codes(self.base, self.count, &shs),
                         _ => unreachable!()
                     }
+                },
+                RadChunkPropertyName::ShLabel => {
+                    let sh_labels = match prop.encoding {
+                        RadChunkPropertyEncoding::U16 => decode_u16_as_u32(data, 1, self.count),
+                        RadChunkPropertyEncoding::U32 => decode_u32(data, 1, self.count),
+                        _ => return Err(anyhow::anyhow!("Unsupported sh label encoding: {:?}", prop.encoding)),
+                    };
+                    self.splats.set_sh_labels(self.base, self.count, &sh_labels);
                 },
                 RadChunkPropertyName::ChildCount => {
                     if prop.encoding != RadChunkPropertyEncoding::U16 {

--- a/rust/spark-lib/src/sh_clustering.rs
+++ b/rust/spark-lib/src/sh_clustering.rs
@@ -1,0 +1,245 @@
+
+use crate::tsplat::{Tsplat, TsplatArray};
+use hnsw::{Hnsw, Searcher};
+use rand_pcg::Pcg64;
+use space::{Metric, Neighbor};
+
+#[derive(Debug, Clone)]
+pub struct ShClusters {
+    pub num_sh: usize,
+    pub num_clusters: usize,
+    pub labels: Vec<usize>,
+    pub weights: Vec<f32>,
+    pub counts: Vec<usize>,
+    pub sh1: Vec<[f32; 9]>,
+    pub sh2: Vec<[f32; 15]>,
+    pub sh3: Vec<[f32; 21]>,
+}
+
+const CHUNK_SIZE: usize = 65536;
+
+pub fn compute_sh_clusters<FNC: FindNearestClusters, TA: TsplatArray>(
+    splats: &TA,
+    num_sh: usize,
+    num_clusters: usize,
+    num_iterations: usize,
+    logger: impl Fn(&str),
+) -> anyhow::Result<ShClusters> {
+    let num_sh = splats.max_sh_degree().min(num_sh);
+    assert!(num_sh >= 1, "num_sh must be at least 1");
+    let dims = match num_sh {
+        0 => 0,
+        1 => 9,
+        2 => 24,
+        3 => 45,
+        _ => unreachable!(),
+    };
+
+    let mut fnc = FNC::create_fnc(dims, num_clusters, CHUNK_SIZE)?;
+
+    let mut clusters = Vec::with_capacity(dims * num_clusters);
+    let mut next_clusters = vec![0.0; dims * num_clusters];
+    let mut cluster_weight = vec![0.0; num_clusters];
+    let mut cluster_count = vec![0; num_clusters];
+    let mut labels = Vec::with_capacity(splats.len());
+    let mut total_weight = 0.0;
+    let mut total_distance;
+
+    for c in 0..num_clusters {
+        let sample = ((c as f32 / num_clusters as f32) * splats.len() as f32).floor() as usize;
+        clusters.extend(splats.get_sh1(sample));
+        if num_sh >= 2 {
+            clusters.extend(splats.get_sh2(sample));
+            if num_sh >= 3 {
+                clusters.extend(splats.get_sh3(sample));
+            }
+        }
+    }
+    logger(&format!("sh_clustering: seeded {} centroids", num_clusters));
+
+    let mut splats_sh = Vec::with_capacity(dims * CHUNK_SIZE);
+
+    for iteration in 0..=num_iterations {
+        let iteration_start_time = std::time::Instant::now();
+        let last_iteration = iteration == num_iterations;
+
+        fnc.set_clusters(dims, &clusters)?;
+        logger(&format!("sh_clustering: Initialized centroids"));
+
+        cluster_weight.fill(0.0);
+        cluster_count.fill(0);
+        labels.clear();
+        total_weight = 0.0;
+        total_distance = 0.0;
+        if !last_iteration {
+            next_clusters.fill(0.0);
+        }
+
+        let mut base = 0;
+        while base < splats.len() {
+            let count = (splats.len() - base).min(CHUNK_SIZE);
+
+            splats_sh.clear();
+            for i in 0..count {
+                splats_sh.extend(splats.get_sh1(base + i));
+                if num_sh >= 2 {
+                    splats_sh.extend(splats.get_sh2(base + i));
+                    if num_sh >= 3 {
+                        splats_sh.extend(splats.get_sh3(base + i));
+                    }
+                }
+            }
+
+            let nearest = fnc.find_nearest_clusters(dims, &splats_sh)?;
+            for (i, (c, distance)) in nearest.into_iter().enumerate() {
+                let c = c as usize;
+                labels.push(c);
+
+                let splat = splats.get(base + i);
+                let weight = splat.opacity() * splat.area();
+                // let weight = 1.0;
+                total_weight += weight;
+                total_distance += weight * distance;
+                cluster_weight[c] += weight;
+                cluster_count[c] += 1;
+
+                if !last_iteration && weight > 0.0 {
+                    let b = i * dims;
+                    for d in 0..dims {
+                        next_clusters[c * dims + d] += weight * splats_sh[b + d];
+                    }
+                }
+            }
+
+            eprint!(".");
+            base += count;
+        }
+        eprintln!();
+
+        let avg_distance = total_distance / total_weight;
+        logger(&format!("sh_clustering: iteration {} avg_distance={:.5}", iteration, avg_distance));
+
+        if last_iteration {
+            break;
+        }
+
+        for c in 0..num_clusters {
+            if cluster_weight[c] > 0.0 {
+                let inv_weight = 1.0 / cluster_weight[c];
+                for d in 0..dims {
+                    next_clusters[c * dims + d] *= inv_weight;
+                }
+            } else {
+                for d in 0..dims {
+                    next_clusters[c * dims + d] = clusters[c * dims + d];
+                }
+            }
+        }
+
+        std::mem::swap(&mut clusters, &mut next_clusters);
+
+        let iteration_duration = iteration_start_time.elapsed();
+        logger(&format!("sh_clustering: iteration {} duration={:.3}s", iteration, iteration_duration.as_secs_f64()));
+    }
+
+    let mut sh1 = Vec::with_capacity(num_clusters);
+    let mut sh2 = Vec::with_capacity(if num_sh >= 2 { num_clusters } else { 0 });
+    let mut sh3 = Vec::with_capacity(if num_sh >= 3 { num_clusters } else { 0 });
+
+    for c in 0..num_clusters {
+        cluster_weight[c] /= total_weight;
+
+        let base = c * dims;
+        sh1.push(std::array::from_fn(|i| clusters[base + i]));
+        if num_sh >= 2 {
+            sh2.push(std::array::from_fn(|i| clusters[base + 9 + i]));
+            if num_sh >= 3 {
+                sh3.push(std::array::from_fn(|i| clusters[base + 24 + i]));
+            }
+        }
+    }
+
+    Ok(ShClusters {
+        num_sh,
+        num_clusters,
+        labels,
+        weights: cluster_weight,
+        counts: cluster_count,
+        sh1,
+        sh2,
+        sh3,
+    })
+}
+
+pub trait FindNearestClusters: Sized {
+    fn create_fnc(max_dims: usize, max_clusters: usize, max_splats: usize) -> anyhow::Result<Self>;
+    fn set_clusters(&mut self, dims: usize, clusters: &[f32]) -> anyhow::Result<()>;
+    fn find_nearest_clusters(&mut self, dims: usize, splats: &[f32]) -> anyhow::Result<Vec<(u32, f32)>>;
+}
+
+pub struct CpuFindNearestClusters {
+    ann: Hnsw<SquaredEuclidean, Vec<f32>, Pcg64, 12, 24>,    
+    ann_searcher: Searcher<u32>,
+}
+
+impl FindNearestClusters for CpuFindNearestClusters {
+    fn create_fnc(_max_dims: usize, _max_clusters: usize, _max_splats: usize) -> anyhow::Result<Self> {
+        println!("CPU SH clustering initialized");
+        Ok(Self {
+            ann: Hnsw::new(SquaredEuclidean),
+            ann_searcher: Searcher::default(),
+        })
+    }
+
+    fn set_clusters(&mut self, dims: usize, clusters: &[f32]) -> anyhow::Result<()> {
+        self.ann = Hnsw::new(SquaredEuclidean);
+        self.ann_searcher = Searcher::default();
+
+        let num_clusters = clusters.len() / dims;
+        assert_eq!(num_clusters * dims, clusters.len());
+
+        for c in 0..num_clusters {
+            let c_index = self.ann.insert(clusters[c * dims..(c + 1) * dims].to_vec(), &mut self.ann_searcher);
+            assert_eq!(c_index, c);
+        }
+
+        Ok(())
+    }
+
+    fn find_nearest_clusters(&mut self, dims: usize, splats: &[f32]) -> anyhow::Result<Vec<(u32, f32)>> {
+        let num_splats = splats.len() / dims;
+        assert_eq!(num_splats * dims, splats.len());
+
+        let mut splat_sh = Vec::new();
+        let mut output = Vec::with_capacity(num_splats);
+
+        for i in 0..num_splats {
+            let base = i * dims;
+            splat_sh.clear();
+            splat_sh.extend(&splats[base..base + dims]);
+
+            let mut closest = [Neighbor {
+                index: !0,
+                distance: !0,
+            }];
+            self.ann.nearest(&splat_sh, 64, &mut self.ann_searcher, &mut closest);
+            output.push((closest[0].index as u32, f32::from_bits(closest[0].distance)));
+        }
+
+        Ok(output)
+    }
+}
+
+struct SquaredEuclidean;
+
+impl Metric<Vec<f32>> for SquaredEuclidean {
+    type Unit = u32;
+
+    fn distance(&self, a: &Vec<f32>, b: &Vec<f32>) -> u32 {
+        a.iter()
+            .zip(b.iter())
+            .map(|(&a, &b)| (a - b).powi(2))
+            .sum::<f32>()
+            .to_bits()
+    }
+}

--- a/rust/spark-worker-rs/Cargo.toml
+++ b/rust/spark-worker-rs/Cargo.toml
@@ -19,7 +19,7 @@ js-sys.workspace = true
 ordered-float.workspace = true
 smallvec.workspace = true
 wasm-bindgen.workspace = true
-web-sys.workspace = true
+web-sys = { workspace = true, features = ["Window", "Performance"] }
 spark-lib = { path = "../spark-lib" }
 serde-wasm-bindgen.workspace = true
 serde_json.workspace = true

--- a/rust/spark-worker-rs/src/ext_splats.rs
+++ b/rust/spark-worker-rs/src/ext_splats.rs
@@ -1,6 +1,6 @@
 use std::array;
 
-use js_sys::{Object, Reflect, Uint32Array};
+use js_sys::{Array, Object, Reflect, Uint32Array};
 use spark_lib::{
     decoder::{SetSplatEncoding, SplatEncoding, SplatGetter, SplatInit, SplatProps, SplatPropsMut, SplatReceiver, copy_getter_to_receiver},
     gsplat::GsplatArray,
@@ -21,6 +21,12 @@ pub struct ExtSplatsData {
     pub sh2: Option<Uint32Array>,
     pub sh3a: Option<Uint32Array>,
     pub sh3b: Option<Uint32Array>,
+    pub sh1_codes_out: Option<Uint32Array>,
+    pub sh2_codes_out: Option<Uint32Array>,
+    pub sh3_codes_out: Option<[Uint32Array; 2]>,
+    sh1_codes: Vec<u32>,
+    sh2_codes: Vec<u32>,
+    sh3_codes: [Vec<u32>; 2],
     pub lod_tree: Option<Uint32Array>,
     child_counts: Option<Vec<u16>>,
     child_starts: Option<Vec<u32>>,
@@ -42,6 +48,12 @@ impl ExtSplatsData {
             sh2: None,
             sh3a: None,
             sh3b: None,
+            sh1_codes_out: None,
+            sh2_codes_out: None,
+            sh3_codes_out: None,
+            sh1_codes: Vec::new(),
+            sh2_codes: Vec::new(),
+            sh3_codes: [Vec::new(), Vec::new()],
             lod_tree: None,
             child_counts: None,
             child_starts: None,
@@ -71,6 +83,18 @@ impl ExtSplatsData {
         }
         if let Some(sh3b) = self.sh3b.as_ref() {
             Reflect::set(&object, &JsValue::from_str("sh3b"), &JsValue::from(sh3b)).unwrap();
+        }
+        if let Some(sh1_codes) = self.sh1_codes_out.as_ref() {
+            Reflect::set(&object, &JsValue::from_str("sh1Codes"), &JsValue::from(sh1_codes)).unwrap();
+        }
+        if let Some(sh2_codes) = self.sh2_codes_out.as_ref() {
+            Reflect::set(&object, &JsValue::from_str("sh2Codes"), &JsValue::from(sh2_codes)).unwrap();
+        }
+        if let Some(sh3_codes) = self.sh3_codes_out.as_ref() {
+            let pair = Array::new();
+            pair.push(&JsValue::from(&sh3_codes[0]));
+            pair.push(&JsValue::from(&sh3_codes[1]));
+            Reflect::set(&object, &JsValue::from_str("sh3Codes"), &JsValue::from(pair)).unwrap();
         }
         if let Some(lod_tree) = self.lod_tree.as_ref() {
             Reflect::set(&object, &JsValue::from_str("lodTree"), &JsValue::from(lod_tree)).unwrap();
@@ -316,6 +340,22 @@ impl ExtSplatsData {
             let sub = lod.subarray((base * 4) as u32, ((base + count) * 4) as u32);
             sub.copy_to(out);
         })
+    }
+
+    pub fn set_sh_codes(&mut self, sh1_codes: Option<Uint32Array>, sh2_codes: Option<Uint32Array>, sh3_codes: Option<Array>) {
+        if let Some(sh1_codes) = sh1_codes {
+            self.sh1_codes = sh1_codes.to_vec();
+        }
+        if let Some(sh2_codes) = sh2_codes {
+            self.sh2_codes = sh2_codes.to_vec();
+        }
+        if let Some(sh3_codes) = sh3_codes {
+            // It's [Uint32Array, Uint32Array]
+            self.sh3_codes = [
+                Uint32Array::from(sh3_codes.get(0)).to_vec(),
+                Uint32Array::from(sh3_codes.get(1)).to_vec(),
+            ];
+        }
     }
 }
 
@@ -578,6 +618,202 @@ impl SplatReceiver for ExtSplatsData {
                 }
                 packed_sh3a.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(&self.buffer_a);
                 packed_sh3b.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(&self.buffer_b);
+            }
+        }
+    }
+
+    fn set_sh1_codes(&mut self, base: usize, count: usize, sh1_codes: &[f32]) {
+        let size = (base + count) * 4;
+        let current_len = self.sh1_codes_out.as_ref().map(|array| array.length()).unwrap_or(0);
+        if size > current_len as usize {
+            let new_array = Uint32Array::new_with_length(size as u32);
+            if let Some(packed_sh1) = self.sh1_codes_out.as_ref() {
+                new_array.set(packed_sh1, 0);
+            }
+            self.sh1_codes_out = Some(new_array);
+        }
+
+        self.invalidate_buffers();
+        self.ensure_buffer_a(count);
+        if let Some(packed_sh1) = self.sh1_codes_out.as_ref() {
+            let buffer = &mut self.buffer_a[0..count * 4];
+            for i in 0..count {
+                let [i3, i4] = [i * 3, i * 4];
+                for k in 0..3 {
+                    let k3 = (i3 + k) * 3;
+                    buffer[i4 + k] = encode_ext_rgb([sh1_codes[k3], sh1_codes[k3 + 1], sh1_codes[k3 + 2]]);
+                }
+            }
+            packed_sh1.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer);
+
+            if (base + count) * 4 > self.sh1_codes.len() {
+                self.sh1_codes.resize((base + count) * 4, 0);
+            }
+            let base4 = base * 4;
+            for i in 0..count {
+                let i4 = i * 4;
+                for k in 0..4 {
+                    self.sh1_codes[base4 + i4 + k] = buffer[i4 + k];
+                }
+            }
+        }
+    }
+
+    fn set_sh2_codes(&mut self, base: usize, count: usize, sh2_codes: &[f32]) {
+        let size = (base + count) * 4;
+        let current_len = self.sh2_codes_out.as_ref().map(|array| array.length()).unwrap_or(0);
+        if size > current_len as usize {
+            let new_array = Uint32Array::new_with_length(size as u32);
+            if let Some(packed_sh2) = self.sh2_codes_out.as_ref() {
+                new_array.set(packed_sh2, 0);
+            }
+            self.sh2_codes_out = Some(new_array);
+        }
+
+        self.invalidate_buffers();
+        self.ensure_buffers(count);
+        if let Some(packed_sh1) = self.sh1_codes_out.as_ref() {
+            if let Some(packed_sh2) = self.sh2_codes_out.as_ref() {
+                let buffer_a = &mut self.buffer_a[0..count * 4];
+                let buffer_b = &mut self.buffer_b[0..count * 4];
+                packed_sh1.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_to(buffer_a);
+                for i in 0..count {
+                    let [i4, i5] = [i * 4, i * 5];
+                    let k3 = i5 * 3;
+                    buffer_a[i4 + 3] = encode_ext_rgb([sh2_codes[k3], sh2_codes[k3 + 1], sh2_codes[k3 + 2]]);
+                    for k in 1..5 {
+                        let k3 = (i5 + k) * 3;
+                        buffer_b[i4 + (k - 1)] = encode_ext_rgb([sh2_codes[k3], sh2_codes[k3 + 1], sh2_codes[k3 + 2]]);
+                    }
+                }
+                packed_sh1.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_a);
+                packed_sh2.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_b);
+
+                if (base + count) * 4 > self.sh2_codes.len() {
+                    self.sh2_codes.resize((base + count) * 4, 0);
+                }
+                let base4 = base * 4;
+                for i in 0..count {
+                    let i4 = i * 4;
+                    self.sh1_codes[base4 + i4 + 3] = buffer_a[i4 + 3];
+                    for k in 1..5 {
+                        self.sh2_codes[base + i4 + (k - 1)] = buffer_b[i4 + (k - 1)];
+                    }
+                }
+            }
+        }
+    }
+
+    fn set_sh3_codes(&mut self, base: usize, count: usize, sh3_codes: &[f32]) {
+        let size = (base + count) * 4;
+        let current_len = self.sh3_codes_out.as_ref().map(|arrays| arrays[0].length()).unwrap_or(0);
+        if size > current_len as usize {
+            let new_arrays = [
+                Uint32Array::new_with_length(size as u32),
+                Uint32Array::new_with_length(size as u32),
+            ];
+            if let Some([packed_sh3a, packed_sh3b]) = self.sh3_codes_out.as_ref() {
+                new_arrays[0].set(packed_sh3a, 0);
+                new_arrays[1].set(packed_sh3b, 0);
+            }
+            self.sh3_codes_out = Some(new_arrays);
+        }
+
+        self.invalidate_buffers();
+        self.ensure_buffers(count);
+        if let Some([packed_sh3a, packed_sh3b]) = self.sh3_codes_out.as_ref() {
+            let buffer_a = &mut self.buffer_a[0..count * 4];
+            let buffer_b = &mut self.buffer_b[0..count * 4];
+            for i in 0..count {
+                let [i4, i7] = [i * 4, i * 7];
+                for k in 0..4 {
+                    let k3 = (i7 + k) * 3;
+                    buffer_a[i4 + k] = encode_ext_rgb([sh3_codes[k3], sh3_codes[k3 + 1], sh3_codes[k3 + 2]]);
+                }
+                for k in 4..7 {
+                    let k3 = (i7 + k) * 3;
+                    buffer_b[i4 + (k - 4)] = encode_ext_rgb([sh3_codes[k3], sh3_codes[k3 + 1], sh3_codes[k3 + 2]]);
+                }
+            }
+            packed_sh3a.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_a);
+            packed_sh3b.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_b);
+
+            if (base + count) * 4 > self.sh3_codes[0].len() {
+                self.sh3_codes[0].resize((base + count) * 4, 0);
+                self.sh3_codes[1].resize((base + count) * 4, 0);
+            }
+            let base4 = base * 4;
+            for i in 0..count {
+                let i4 = i * 4;
+                for k in 0..4 {
+                    self.sh3_codes[0][base4 + i4 + k] = buffer_a[i4 + k];
+                }
+                for k in 4..7 {
+                    self.sh3_codes[1][base4 + i4 + (k - 4)] = buffer_b[i4 + (k - 4)];
+                }
+            }
+        }
+    }
+
+    fn set_sh_labels(&mut self, base: usize, count: usize, sh_labels: &[u32]) {
+        if self.max_sh_degree == 0 {
+            return;
+        }
+        self.invalidate_buffers();
+        self.ensure_buffers(count);
+
+        if let Some(packed_sh1) = self.sh1.as_ref() {
+            let buffer_a = &mut self.buffer_a[0..count * 4];
+            for i in 0..count {
+                let label = sh_labels[i] as usize;
+                let i4 = i * 4;
+                let l4 = label * 4;
+                for k in 0..4 {
+                    buffer_a[i4 + k] = self.sh1_codes[l4 + k];
+                }
+            }
+
+            if self.max_sh_degree == 1 {
+                packed_sh1.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_a);
+                return;
+            }
+
+            if let Some(packed_sh2) = self.sh2.as_ref() {
+                let buffer_b = &mut self.buffer_b[0..count * 4];
+                for i in 0..count {
+                    let label = sh_labels[i] as usize;
+                    let i4 = i * 4;
+                    let l4 = label * 4;
+                    buffer_a[i4 + 3] = self.sh2_codes[l4 + 0];
+                    for k in 1..5 {
+                        buffer_b[i4 + (k - 1)] = self.sh2_codes[l4 + (k - 1)];
+                    }
+                }
+
+                packed_sh1.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_a);
+                packed_sh2.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_b);
+                
+                if self.max_sh_degree == 2 {
+                    return;
+                }
+
+                if let Some(packed_sh3a) = self.sh3a.as_ref() {
+                    if let Some(packed_sh3b) = self.sh3b.as_ref() {
+                        for i in 0..count {
+                            let label = sh_labels[i] as usize;
+                            let i4 = i * 4;
+                            let l4 = label * 4;
+                            for k in 0..4 {
+                                buffer_a[i4 + k] = self.sh3_codes[0][l4 + k];
+                            }
+                            for k in 4..7 {
+                                buffer_b[i4 + (k - 4)] = self.sh3_codes[1][l4 + (k - 4)];
+                            }
+                        }
+                        packed_sh3a.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_a);
+                        packed_sh3b.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer_b);
+                    }
+                }
             }
         }
     }

--- a/rust/spark-worker-rs/src/lib.rs
+++ b/rust/spark-worker-rs/src/lib.rs
@@ -1,6 +1,6 @@
 
 use std::cell::RefCell;
-use js_sys::{Object, Reflect, Uint8Array, Uint16Array, Uint32Array};
+use js_sys::{Array, Object, Reflect, Uint8Array, Uint16Array, Uint32Array};
 use spark_lib::decoder::{ChunkReceiver, MultiDecoder, SplatEncoding, SplatFileType, SplatGetter};
 use spark_lib::gsplat::GsplatArray as GsplatArrayInner;
 use spark_lib::csplat::CsplatArray as CsplatArrayInner;
@@ -93,7 +93,10 @@ pub fn sort32_splats(
 }
 
 #[wasm_bindgen]
-pub fn decode_to_packedsplats(file_type: Option<String>, path_name: Option<String>, encoding: JsValue) -> Result<ChunkDecoder, JsValue> {
+pub fn decode_to_packedsplats(
+    file_type: Option<String>, path_name: Option<String>, encoding: JsValue,
+    sh1_codes: Option<Uint32Array>, sh2_codes: Option<Uint32Array>, sh3_codes: Option<Uint32Array>,
+) -> Result<ChunkDecoder, JsValue> {
     let encoding = if encoding.is_falsy() {
         SplatEncoding::default()
     } else {
@@ -109,7 +112,9 @@ pub fn decode_to_packedsplats(file_type: Option<String>, path_name: Option<Strin
         None
     };
 
-    let splats = PackedSplatsData::new(encoding);
+    let mut splats = PackedSplatsData::new(encoding);
+    splats.set_sh_codes(sh1_codes, sh2_codes, sh3_codes);
+
     let decoder = MultiDecoder::new(splats, file_type, path_name.as_deref());
     let on_finish = |receiver: Box<dyn ChunkReceiver>| {
         let decoder: Box<MultiDecoder<PackedSplatsData>> = receiver.into_any().downcast().unwrap();
@@ -124,7 +129,10 @@ pub fn decode_to_packedsplats(file_type: Option<String>, path_name: Option<Strin
 }
 
 #[wasm_bindgen]
-pub fn decode_to_extsplats(file_type: Option<String>, path_name: Option<String>) -> Result<ChunkDecoder, JsValue> {
+pub fn decode_to_extsplats(
+    file_type: Option<String>, path_name: Option<String>,
+    sh1_codes: Option<Uint32Array>, sh2_codes: Option<Uint32Array>, sh3_codes: Option<Array>,
+) -> Result<ChunkDecoder, JsValue> {
     let file_type = if let Some(file_type) = file_type {
         match SplatFileType::from_enum_str(&file_type) {
             Ok(file_type) => Some(file_type),
@@ -134,7 +142,9 @@ pub fn decode_to_extsplats(file_type: Option<String>, path_name: Option<String>)
         None
     };
 
-    let splats = ExtSplatsData::new();
+    let mut splats = ExtSplatsData::new();
+    splats.set_sh_codes(sh1_codes, sh2_codes, sh3_codes);
+
     let decoder = MultiDecoder::new(splats, file_type, path_name.as_deref());
     let on_finish = |receiver: Box<dyn ChunkReceiver>| {
         let decoder: Box<MultiDecoder<ExtSplatsData>> = receiver.into_any().downcast().unwrap();

--- a/rust/spark-worker-rs/src/packed_splats.rs
+++ b/rust/spark-worker-rs/src/packed_splats.rs
@@ -16,6 +16,12 @@ pub struct PackedSplatsData {
     pub sh1: Option<Uint32Array>,
     pub sh2: Option<Uint32Array>,
     pub sh3: Option<Uint32Array>,
+    pub sh1_codes_out: Option<Uint32Array>,
+    pub sh2_codes_out: Option<Uint32Array>,
+    pub sh3_codes_out: Option<Uint32Array>,
+    sh1_codes: Vec<u32>,
+    sh2_codes: Vec<u32>,
+    sh3_codes: Vec<u32>,
     pub lod_tree: Option<Uint32Array>,
     child_counts: Option<Vec<u16>>,
     child_starts: Option<Vec<u32>>,
@@ -36,6 +42,12 @@ impl PackedSplatsData {
             sh1: None,
             sh2: None,
             sh3: None,
+            sh1_codes_out: None,
+            sh2_codes_out: None,
+            sh3_codes_out: None,
+            sh1_codes: Vec::new(),
+            sh2_codes: Vec::new(),
+            sh3_codes: Vec::new(),
             lod_tree: None,
             child_counts: None,
             child_starts: None,
@@ -61,6 +73,15 @@ impl PackedSplatsData {
         }
         if let Some(sh3) = self.sh3.as_ref() {
             Reflect::set(&object, &JsValue::from_str("sh3"), &JsValue::from(sh3)).unwrap();
+        }
+        if let Some(sh1_codes) = self.sh1_codes_out.as_ref() {
+            Reflect::set(&object, &JsValue::from_str("sh1Codes"), &JsValue::from(sh1_codes)).unwrap();
+        }
+        if let Some(sh2_codes) = self.sh2_codes_out.as_ref() {
+            Reflect::set(&object, &JsValue::from_str("sh2Codes"), &JsValue::from(sh2_codes)).unwrap();
+        }
+        if let Some(sh3_codes) = self.sh3_codes_out.as_ref() {
+            Reflect::set(&object, &JsValue::from_str("sh3Codes"), &JsValue::from(sh3_codes)).unwrap();
         }
         if let Some(lod_tree) = self.lod_tree.as_ref() {
             Reflect::set(&object, &JsValue::from_str("lodTree"), &JsValue::from(lod_tree)).unwrap();
@@ -296,6 +317,18 @@ impl PackedSplatsData {
             let sub = lod.subarray((base * 4) as u32, ((base + count) * 4) as u32);
             sub.copy_to(out);
         })
+    }
+
+    pub fn set_sh_codes(&mut self, sh1_codes: Option<Uint32Array>, sh2_codes: Option<Uint32Array>, sh3_codes: Option<Uint32Array>) {
+        if let Some(sh1_codes) = sh1_codes {
+            self.sh1_codes = sh1_codes.to_vec();
+        }
+        if let Some(sh2_codes) = sh2_codes {
+            self.sh2_codes = sh2_codes.to_vec();
+        }
+        if let Some(sh3_codes) = sh3_codes {
+            self.sh3_codes = sh3_codes.to_vec();
+        }
     }
 }
 
@@ -546,6 +579,156 @@ impl SplatReceiver for PackedSplatsData {
             let SplatEncoding { sh3_max, .. } = self.encoding;
             encode_sh3_array(&mut self.buffer, sh3, count, sh3_max);
             packed_sh3.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(&self.buffer);
+        }
+    }
+
+    fn set_sh1_codes(&mut self, base: usize, count: usize, sh1_codes: &[f32]) {
+        let size = (base + count) * 2;
+        let current_len = self.sh1_codes_out.as_ref().map(|array| array.length()).unwrap_or(0);
+        if size > current_len as usize {
+            let new_array = Uint32Array::new_with_length(size as u32);
+            if let Some(packed_sh1_codes) = self.sh1_codes_out.as_ref() {
+                new_array.set(packed_sh1_codes, 0);
+            }
+            self.sh1_codes_out = Some(new_array);
+        }
+
+        self.invalidate_buffer();
+        self.ensure_buffer(count);
+        if let Some(packed_sh1_codes) = self.sh1_codes_out.as_ref() {
+            let buffer = &mut self.buffer[0..count * 2];
+            let SplatEncoding { sh1_max, .. } = self.encoding;
+            encode_sh1_array(buffer, sh1_codes, count, sh1_max);
+            packed_sh1_codes.subarray((base * 2) as u32, ((base + count) * 2) as u32).copy_from(buffer);
+
+            if (base + count) * 2 > self.sh1_codes.len() {
+                self.sh1_codes.resize((base + count) * 2, 0);
+            }
+            let base2 = base * 2;
+            for i in 0..count {
+                let i2 = i * 2;
+                self.sh1_codes[base2 + i2] = buffer[i2];
+                self.sh1_codes[base2 + i2 + 1] = buffer[i2 + 1];
+            }
+        }
+    }
+
+    fn set_sh2_codes(&mut self, base: usize, count: usize, sh2_codes: &[f32]) {
+        let size = (base + count) * 4;
+        let current_len = self.sh2_codes_out.as_ref().map(|array| array.length()).unwrap_or(0);
+        if size > current_len as usize {
+            let new_array = Uint32Array::new_with_length(size as u32);
+            if let Some(packed_sh2_codes) = self.sh2_codes_out.as_ref() {
+                new_array.set(packed_sh2_codes, 0);
+            }
+            self.sh2_codes_out = Some(new_array);
+        }
+
+        self.invalidate_buffer();
+        self.ensure_buffer(count);
+        if let Some(packed_sh2_codes) = self.sh2_codes_out.as_ref() {
+            let buffer = &mut self.buffer[0..count * 4];
+            let SplatEncoding { sh2_max, .. } = self.encoding;
+            encode_sh2_array(buffer, sh2_codes, count, sh2_max);
+            packed_sh2_codes.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer);
+
+            if (base + count) * 4 > self.sh2_codes.len() {
+                self.sh2_codes.resize((base + count) * 4, 0);
+            }
+            let base4 = base * 4;
+            for i in 0..count {
+                let i4 = i * 4;
+                for k in 0..4 {
+                    self.sh2_codes[base4 + i4 + k] = buffer[i4 + k];
+                }
+            }
+        }
+    }
+
+    fn set_sh3_codes(&mut self, base: usize, count: usize, sh3_codes: &[f32]) {
+        let size = (base + count) * 4;
+        let current_len = self.sh3_codes_out.as_ref().map(|array| array.length()).unwrap_or(0);
+        if size > current_len as usize {
+            let new_array = Uint32Array::new_with_length(size as u32);
+            if let Some(packed_sh3_codes) = self.sh3_codes_out.as_ref() {
+                new_array.set(packed_sh3_codes, 0);
+            }
+            self.sh3_codes_out = Some(new_array);
+        }
+
+        self.invalidate_buffer();
+        self.ensure_buffer(count);
+        if let Some(packed_sh3_codes) = self.sh3_codes_out.as_ref() {
+            let buffer = &mut self.buffer[0..count * 4];
+            let SplatEncoding { sh3_max, .. } = self.encoding;
+            encode_sh3_array(buffer, sh3_codes, count, sh3_max);
+            packed_sh3_codes.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer);
+
+            if (base + count) * 4 > self.sh3_codes.len() {
+                self.sh3_codes.resize((base + count) * 4, 0);
+            }
+            let base4 = base * 4;
+            for i in 0..count {
+                let i4 = i * 4;
+                for k in 0..4 {
+                    self.sh3_codes[base4 + i4 + k] = buffer[i4 + k];
+                }
+            }
+        }
+    }
+
+    fn set_sh_labels(&mut self, base: usize, count: usize, sh_labels: &[u32]) {
+        if self.max_sh_degree == 0 {
+            return;
+        }
+        self.invalidate_buffer();
+        self.ensure_buffer(count);
+
+        if let Some(packed_sh1) = self.sh1.as_ref() {
+            let buffer = &mut self.buffer[0..count * 2];
+            for i in 0..count {
+                let label = sh_labels[i] as usize;
+                let i2 = i * 2;
+                let l2 = label * 2;
+                buffer[i2] = self.sh1_codes[l2];
+                buffer[i2 + 1] = self.sh1_codes[l2 + 1];        
+            }
+            packed_sh1.subarray((base * 2) as u32, ((base + count) * 2) as u32).copy_from(buffer);
+
+            if self.max_sh_degree == 1 {
+                return;
+            }
+
+            if let Some(packed_sh2) = self.sh2.as_ref() {
+                let buffer = &mut self.buffer[0..count * 4];
+                for i in 0..count {
+                    let label = sh_labels[i] as usize;
+                    let i4 = i * 4;
+                    let l4 = label * 4;
+                    for k in 0..4 {
+                        buffer[i4 + k] = self.sh2_codes[l4 + k];
+                    }
+                }
+
+                packed_sh2.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer);
+                
+                if self.max_sh_degree == 2 {
+                    return;
+                }
+
+                if let Some(packed_sh3) = self.sh3.as_ref() {
+                    let buffer = &mut self.buffer[0..count * 4];
+                    for i in 0..count {
+                        let label = sh_labels[i] as usize;
+                        let i4 = i * 4;
+                        let l4 = label * 4;
+                        for k in 0..4 {
+                            buffer[i4 + k] = self.sh3_codes[l4 + k];
+                        }
+                    }
+                    packed_sh3.subarray((base * 4) as u32, ((base + count) * 4) as u32).copy_from(buffer);
+                }
+            }
         }
     }
 

--- a/src/PackedSplats.ts
+++ b/src/PackedSplats.ts
@@ -758,7 +758,7 @@ export class PackedSplats implements SplatSource {
       // Create a program from the template and graph
       program = new DynoProgram({
         graph,
-        inputs: { index: "index" },
+        inputs: { index: "_index" },
         outputs: { output: "target" },
         template: PackedSplats.programTemplate,
       });

--- a/src/Readback.ts
+++ b/src/Readback.ts
@@ -117,7 +117,7 @@ export class Readback {
       // Create a program from the template and graph
       program = new DynoProgram({
         graph,
-        inputs: { index: "index" },
+        inputs: { index: "_index" },
         outputs: { rgba8: "target" },
         template: Readback.programTemplate,
       });

--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -31,6 +31,11 @@ export interface SparkRendererOptions {
    */
   renderer: THREE.WebGLRenderer;
   /**
+   * Callback function to be called when SparkRenderer needs to re-render,
+   * for example when splat sort order or LoD updates complete.
+   */
+  onDirty?: () => void;
+  /**
    * Whether to use premultiplied alpha when accumulating splat RGB
    * @default true
    */
@@ -100,6 +105,12 @@ export interface SparkRendererOptions {
    * @default false
    */
   enable2DGS?: boolean;
+  /**
+   * Enable alternative ray-splat max response evaluation, used by 3DGUT (unscented transform),
+   * 3DGRT, and HTGS.
+   * @default false
+   */
+  // enableRayEval?: boolean;
   /**
    * Scalar value to add to 2D splat covariance diagonal, effectively blurring +
    * enlarging splats. In scenes trained without the Gsplat anti-aliasing tweak
@@ -189,6 +200,11 @@ export interface SparkRendererOptions {
    */
   lodRenderScale?: number;
   /**
+   * Inflate LoD splats to ensure opacity stays <= 1.0, producing a softer appearance.
+   * @default false
+   */
+  lodInflate?: boolean;
+  /**
    * Whether to use extended Gsplat encoding for paged splats, useful for eliminating
    * quantization artifacts from splat scenes with large internal position coordinates.
    * @default false
@@ -229,6 +245,11 @@ export interface SparkRendererOptions {
    * @default 0.2
    */
   behindFoveate?: number;
+  /* How many LoD splats to generate for raycasting
+   * @default 10000-25000 iff default canvas target is used
+   */
+  lodRaycast?: number;
+  lodRaycastIntervalMs?: number;
   /* Configures an offline render target for the SparkRenderer (as opposed to
    * rendering to the canvas). This is useful for rendering environment maps,
    * additional viewpoints, or video frame rendering.
@@ -257,7 +278,7 @@ export interface SparkRendererOptions {
      * @default 1
      */
     superXY?: number;
-  };
+  } & THREE.RenderTargetOptions;
   /* Extra uniform values to pass to the shader.
    * @default undefined = no extra uniforms
    */
@@ -307,6 +328,7 @@ export class SparkRenderer extends THREE.Mesh {
   covSplats: boolean;
   minAlpha: number;
   enable2DGS: boolean;
+  // enableRayEval: boolean;
   preBlurAmount: number;
   blurAmount: number;
   focalDistance: number;
@@ -323,6 +345,8 @@ export class SparkRenderer extends THREE.Mesh {
   time?: number;
   lastFrame = -1;
   updateTimeoutId = -1;
+  onDirty?: () => void;
+  dirty: boolean;
 
   orderingTexture: THREE.DataTexture | null = null;
   maxSplats = 0;
@@ -346,14 +370,18 @@ export class SparkRenderer extends THREE.Mesh {
   lodSplatCount?: number;
   lodSplatScale: number;
   lodRenderScale: number;
+  lodInflate: boolean;
   pagedExtSplats: boolean;
   maxPagedSplats: number;
   numLodFetchers: number;
-  outsideFoveate: number;
   behindFoveate: number;
   coneFov0: number;
   coneFov: number;
   coneFoveate: number;
+
+  lodRaycast?: number;
+  lodRaycastIntervalMs: number;
+  lastLodRaycastTime = 0;
 
   lodWorker: SplatWorker | null = null;
   lodMeshes: { mesh: SplatMesh; version: number }[] = [];
@@ -368,8 +396,6 @@ export class SparkRenderer extends THREE.Mesh {
   lastLod?: {
     pos: THREE.Vector3;
     quat: THREE.Quaternion;
-    fovXdegrees: number;
-    fovYdegrees: number;
     pixelScaleLimit: number;
     maxSplats: number;
     timestamp: number;
@@ -448,6 +474,8 @@ export class SparkRenderer extends THREE.Mesh {
 
     // sparkRendererInstance = this;
     this.renderer = options.renderer;
+    this.onDirty = options.onDirty;
+    this.dirty = true;
     this.premultipliedAlpha = premultipliedAlpha;
     this.autoUpdate = options.autoUpdate ?? true;
     this.preUpdate = options.preUpdate ?? true;
@@ -459,6 +487,7 @@ export class SparkRenderer extends THREE.Mesh {
     this.covSplats = options.covSplats ?? false;
     this.minAlpha = options.minAlpha ?? 0.5 * (1.0 / 255.0);
     this.enable2DGS = options.enable2DGS ?? false;
+    // this.enableRayEval = options.enableRayEval ?? false;
     this.preBlurAmount = options.preBlurAmount ?? 0.0;
     this.blurAmount = options.blurAmount ?? 0.3;
     this.focalDistance = options.focalDistance ?? 0.0;
@@ -477,15 +506,23 @@ export class SparkRenderer extends THREE.Mesh {
     this.lodSplatCount = options.lodSplatCount;
     this.lodSplatScale = options.lodSplatScale ?? 1.0;
     this.lodRenderScale = options.lodRenderScale ?? 1.0;
+    this.lodInflate = options.lodInflate ?? false;
     this.pagedExtSplats = options.pagedExtSplats ?? false;
     const defaultPages = isMobile() ? (isIos() ? 96 : 128) : 256;
     this.maxPagedSplats = options.maxPagedSplats ?? defaultPages * 65536;
     this.numLodFetchers = options.numLodFetchers ?? 3;
-    this.outsideFoveate = 1.0;
     this.behindFoveate = options.behindFoveate ?? 0.2;
     this.coneFov0 = options.coneFov0 ?? 90.0;
     this.coneFov = options.coneFov ?? 120.0;
     this.coneFoveate = options.coneFoveate ?? 0.4;
+
+    this.lodRaycast =
+      options.lodRaycast === undefined
+        ? isMobile()
+          ? 10000
+          : 25000
+        : options.lodRaycast;
+    this.lodRaycastIntervalMs = options.lodRaycastIntervalMs ?? 500;
 
     this.clock = options.clock ? cloneClock(options.clock) : new THREE.Clock();
 
@@ -499,8 +536,14 @@ export class SparkRenderer extends THREE.Mesh {
     this.accumulators.push(new SplatAccumulator(accumulatorOptions));
 
     if (options.target) {
-      const { width, height, doubleBuffer } = options.target;
-      const superXY = Math.max(1, Math.min(4, options.target.superXY ?? 1));
+      const {
+        width,
+        height,
+        doubleBuffer,
+        superXY: origSuperXY,
+        ...origTargetOptions
+      } = options.target;
+      const superXY = Math.max(1, Math.min(4, origSuperXY ?? 1));
       if (width * superXY > 8192 || height * superXY > 8192) {
         throw new Error("Target size too large");
       }
@@ -512,6 +555,7 @@ export class SparkRenderer extends THREE.Mesh {
         format: THREE.RGBAFormat,
         type: THREE.UnsignedByteType,
         colorSpace: THREE.SRGBColorSpace,
+        ...origTargetOptions,
       };
 
       this.target = new THREE.WebGLRenderTarget(
@@ -555,6 +599,10 @@ export class SparkRenderer extends THREE.Mesh {
       minAlpha: { value: 0.5 * (1.0 / 255.0) },
       // Enable interpreting 0-thickness Gsplats as 2DGS
       enable2DGS: { value: false },
+      // Enable ray-splat max response evaluation
+      // enableRayEval: { value: false },
+      // Inflate LoD splats so that opacity <= 1.0
+      lodInflate: { value: false },
       // Add to projected 2D splat covariance diagonal (thickens and brightens)
       preBlurAmount: { value: 0.0 },
       // Add to 2D splat covariance diagonal and adjust opacity (anti-aliasing)
@@ -633,6 +681,13 @@ export class SparkRenderer extends THREE.Mesh {
     }
   }
 
+  setDirty() {
+    if (!this.dirty) {
+      this.dirty = true;
+      this.onDirty?.();
+    }
+  }
+
   onBeforeRender(
     renderer: THREE.WebGLRenderer,
     scene: THREE.Scene,
@@ -691,6 +746,8 @@ export class SparkRenderer extends THREE.Mesh {
     this.uniforms.maxPixelRadius.value = spark.maxPixelRadius;
     this.uniforms.minAlpha.value = spark.minAlpha;
     this.uniforms.enable2DGS.value = spark.enable2DGS;
+    // this.uniforms.enableRayEval.value = spark.enableRayEval;
+    this.uniforms.lodInflate.value = spark.lodInflate;
     this.uniforms.preBlurAmount.value = spark.preBlurAmount;
     this.uniforms.blurAmount.value = spark.blurAmount;
     this.uniforms.focalDistance.value = spark.focalDistance;
@@ -743,6 +800,8 @@ export class SparkRenderer extends THREE.Mesh {
         }
       }
     }
+
+    spark.dirty = false;
   }
 
   async update({
@@ -810,7 +869,7 @@ export class SparkRenderer extends THREE.Mesh {
         "Next accumulator is the same as the current accumulator",
       );
     }
-    const { version, mappingVersion, visibleGenerators, generate, readback } =
+    const { version, mappingVersion, visibleGenerators, generate } =
       next.prepareGenerate({
         renderer,
         scene,
@@ -862,6 +921,7 @@ export class SparkRenderer extends THREE.Mesh {
 
       this.current = next;
       this.sortDirty = true;
+      this.setDirty();
     }
 
     if (this.enableDriveLod) {
@@ -933,7 +993,7 @@ export class SparkRenderer extends THREE.Mesh {
       readback,
       ordering,
     })) as {
-      readback: Uint16Array | Uint32Array;
+      readback: Uint32Array<ArrayBuffer>;
       ordering: Uint32Array;
       activeSplats: number;
     };
@@ -942,7 +1002,7 @@ export class SparkRenderer extends THREE.Mesh {
       await new Promise((resolve) => setTimeout(resolve, this.sortDelay));
     }
 
-    this.readback32 = result.readback as Uint32Array<ArrayBuffer>;
+    this.readback32 = result.readback;
 
     this.activeSplats = result.activeSplats;
 
@@ -1007,6 +1067,7 @@ export class SparkRenderer extends THREE.Mesh {
       }
     }
     this.sorting = false;
+    this.setDirty();
 
     this.driveSort();
   }
@@ -1044,15 +1105,19 @@ export class SparkRenderer extends THREE.Mesh {
     const maxSplats = splatCount * this.lodSplatScale;
 
     let pixelScaleLimit = 0.0;
-    let fovXdegrees = Number.POSITIVE_INFINITY;
-    let fovYdegrees = Number.POSITIVE_INFINITY;
     if (camera instanceof THREE.PerspectiveCamera) {
       const tanYfov = Math.tan((0.5 * camera.fov * Math.PI) / 180);
       pixelScaleLimit = (2.0 * tanYfov) / this.renderSize.y;
-      fovYdegrees = camera.fov;
-      fovXdegrees =
-        ((Math.atan(tanYfov * camera.aspect) * 180) / Math.PI) * 2.0;
+    } else if (camera instanceof THREE.OrthographicCamera) {
+      // Effective visible size after zoom
+      const viewHeight = (camera.top - camera.bottom) / camera.zoom;
+      const viewWidth = (camera.right - camera.left) / camera.zoom;
+      // World/view units per pixel (constant with depth for ortho)
+      const pxY = viewHeight / Math.max(1, this.renderSize.y);
+      const pxX = viewWidth / Math.max(1, this.renderSize.x);
+      pixelScaleLimit = Math.min(pxX, pxY);
     }
+
     pixelScaleLimit *= this.lodRenderScale;
 
     const viewPos = new THREE.Vector3();
@@ -1061,13 +1126,18 @@ export class SparkRenderer extends THREE.Mesh {
 
     if (this.lastLod) {
       if (
-        viewPos.distanceTo(this.lastLod.pos) > 0.001 ||
-        viewQuat.dot(this.lastLod.quat) < 0.999 ||
-        this.lastLod.fovXdegrees !== fovXdegrees ||
-        this.lastLod.fovYdegrees !== fovYdegrees ||
         this.lastLod.pixelScaleLimit !== pixelScaleLimit ||
         this.lastLod.maxSplats !== maxSplats
       ) {
+        this.lodDirty = true;
+      }
+
+      const distance = viewPos.distanceTo(this.lastLod.pos);
+      const distanceRamp = Math.max(0.0, 1.0 - distance / 1.0);
+      const dot = viewQuat.dot(this.lastLod.quat);
+      const quatRamp = Math.max(0.0, 1.0 - (1.0 - dot) / 0.01);
+      const similarity = distanceRamp * quatRamp;
+      if (similarity < 0.999) {
         this.lodDirty = true;
       }
     }
@@ -1189,10 +1259,10 @@ export class SparkRenderer extends THREE.Mesh {
       }
 
       if (this.lodDirty) {
+        const now = performance.now();
         const deltaPred = new THREE.Vector3();
         if (this.lastLod) {
-          const now = performance.now();
-          const deltaTime = now - this.lastLod.timestamp;
+          const deltaTime = Math.max(1, now - this.lastLod.timestamp);
           deltaPred
             .copy(viewPos)
             .sub(this.lastLod.pos)
@@ -1201,8 +1271,6 @@ export class SparkRenderer extends THREE.Mesh {
         this.lastLod = {
           pos: viewPos,
           quat: viewQuat,
-          fovXdegrees,
-          fovYdegrees,
           pixelScaleLimit,
           maxSplats,
           timestamp: now,
@@ -1217,9 +1285,8 @@ export class SparkRenderer extends THREE.Mesh {
           scene,
           maxSplats,
           pixelScaleLimit,
-          fovXdegrees,
-          fovYdegrees,
         );
+        this.setDirty();
       }
 
       await this.cleanupLodTrees(worker);
@@ -1258,8 +1325,6 @@ export class SparkRenderer extends THREE.Mesh {
     scene: THREE.Scene,
     maxSplats: number,
     pixelScaleLimit: number,
-    fovXdegrees: number,
-    fovYdegrees: number,
   ) {
     const uuidToMesh: Map<string, SplatMesh> = new Map();
 
@@ -1288,11 +1353,11 @@ export class SparkRenderer extends THREE.Mesh {
         }
 
         instances[mesh.uuid] = {
+          instanceId: mesh.uuid,
           lodId: record.lodId,
           rootPage: record.rootPage,
           viewToObjectCols: viewToObject.elements,
           lodScale: mesh.lodScale,
-          outsideFoveate: mesh.outsideFoveate ?? this.outsideFoveate,
           behindFoveate: mesh.behindFoveate ?? this.behindFoveate,
           coneFov0: mesh.coneFov0 ?? this.coneFov0,
           coneFov: mesh.coneFov ?? this.coneFov,
@@ -1303,11 +1368,11 @@ export class SparkRenderer extends THREE.Mesh {
       {} as Record<
         string,
         {
+          instanceId: string;
           lodId: number;
           rootPage?: number;
           viewToObjectCols: number[];
           lodScale: number;
-          outsideFoveate: number;
           behindFoveate: number;
           coneFov0: number;
           coneFov: number;
@@ -1317,17 +1382,12 @@ export class SparkRenderer extends THREE.Mesh {
     );
 
     const traverseStart = performance.now();
-    const { keyIndices, chunks, pixelLimit } = (await worker.call(
-      "traverseLodTrees",
-      {
-        maxSplats,
-        pixelScaleLimit,
-        lastPixelLimit: this.lastPixelLimit,
-        fovXdegrees,
-        fovYdegrees,
-        instances,
-      },
-    )) as {
+    const result = (await worker.call("traverseLodTrees", {
+      maxSplats,
+      pixelScaleLimit,
+      lastPixelLimit: this.lastPixelLimit,
+      instances,
+    })) as {
       keyIndices: Record<
         string,
         { lodId: number; numSplats: number; indices: Uint32Array }
@@ -1336,6 +1396,8 @@ export class SparkRenderer extends THREE.Mesh {
       pixelLimit?: number;
     };
     this.lastTraverseTime = performance.now() - traverseStart;
+
+    const { keyIndices, chunks, pixelLimit } = result;
     this.lastPixelLimit = pixelLimit;
     const totalLodSplats = Object.values(keyIndices).reduce(
       (sum, { numSplats }) => sum + numSplats,
@@ -1389,6 +1451,37 @@ export class SparkRenderer extends THREE.Mesh {
       }
 
       this.pager.driveFetchers();
+    }
+
+    if (
+      this.lodRaycast &&
+      performance.now() - this.lastLodRaycastTime >= this.lodRaycastIntervalMs
+    ) {
+      this.lastLodRaycastTime = performance.now();
+      const traverseStart = performance.now();
+      const result = (await worker.call("traverseLodTrees", {
+        maxSplats: Math.min(this.lodRaycast, Math.round(totalLodSplats * 0.1)),
+        pixelScaleLimit,
+        instances,
+      })) as {
+        keyIndices: Record<
+          string,
+          { lodId: number; numSplats: number; indices: Uint32Array }
+        >;
+      };
+      const raycastTraverseTime = performance.now() - traverseStart;
+
+      const { keyIndices } = result;
+      const totalRaycastSplats = Object.values(keyIndices).reduce(
+        (sum, { numSplats }) => sum + numSplats,
+        0,
+      );
+      for (const [uuid, countIndices] of Object.entries(keyIndices)) {
+        const mesh = uuidToMesh.get(uuid) as SplatMesh;
+        mesh.raycastIndices = countIndices;
+        // console.log("Set raycast indices", uuid, countIndices.numSplats, countIndices.indices.length);
+      }
+      // console.log(`raycast traverse in ${raycastTraverseTime} ms, totalRaycastSplats=${totalRaycastSplats}`);
     }
   }
 
@@ -1467,7 +1560,7 @@ export class SparkRenderer extends THREE.Mesh {
           this.lodInstances.set(mesh, instance);
         } else {
           instance.numSplats = numSplats;
-          instance.indices.set(indices.subarray(0, numSplats));
+          // instance.indices.set(indices.subarray(0, numSplats));
 
           const renderer = this.renderer;
           const gl = renderer.getContext() as WebGL2RenderingContext;

--- a/src/SparkXr.ts
+++ b/src/SparkXr.ts
@@ -79,6 +79,7 @@ export interface SparkXrControllers {
   fastMultiplier?: number;
   slowMultiplier?: number;
   moveHeading?: boolean;
+  moveDirection?: boolean;
   getMove?: (gamepads: XrGamepads, sparkXr: SparkXr) => THREE.Vector3;
   getRotate?: (gamepads: XrGamepads, sparkXr: SparkXr) => THREE.Vector3;
   getFast?: (gamepads: XrGamepads, sparkXr: SparkXr) => boolean;
@@ -633,6 +634,12 @@ export class SparkXr {
 
     if (this.controllers?.moveHeading) {
       move.applyQuaternion(camera.quaternion);
+    } else if (this.controllers?.moveDirection) {
+      SCRATCH_EULER.setFromQuaternion(camera.quaternion, "YXZ");
+      SCRATCH_EULER.x = 0;
+      SCRATCH_EULER.z = 0;
+      SCRATCH_QUAT_A.setFromEuler(SCRATCH_EULER);
+      move.applyQuaternion(SCRATCH_QUAT_A);
     }
     move.applyQuaternion(cameraFrame.quaternion);
 
@@ -723,6 +730,7 @@ type HandsSnapshot = {
 };
 
 const round4 = (value: number) => Math.round(value * 10000) / 10000;
+const SCRATCH_EULER = new THREE.Euler(0, 0, 0, "YXZ");
 const SCRATCH_QUAT_A = new THREE.Quaternion();
 const SCRATCH_QUAT_B = new THREE.Quaternion();
 

--- a/src/SplatAccumulator.ts
+++ b/src/SplatAccumulator.ts
@@ -329,7 +329,7 @@ export class SplatAccumulator {
       );
       program = new DynoProgram({
         graph,
-        inputs: { index: "index" },
+        inputs: { index: "_index" },
         outputs: {},
         template: this.extSplats
           ? SplatAccumulator.programExtTemplate

--- a/src/SplatLoader.ts
+++ b/src/SplatLoader.ts
@@ -97,6 +97,8 @@ export class SplatLoader extends Loader {
       ? undefined
       : this.manager.resolveURL((this.path ?? "") + (url ?? ""));
 
+    let readStream = stream?.getReader();
+
     this.manager.itemStart(resolvedURL ?? "");
     // let calledOnLoad = false;
 
@@ -129,7 +131,7 @@ export class SplatLoader extends Loader {
         //   extra: Record<string, unknown>;
         // } | null = null;
 
-        const onStatus = (data: unknown) => {
+        const onStatus = async (data: unknown) => {
           const { loaded, total } = data as { loaded: number; total: number };
           if (loaded !== undefined && onProgress) {
             onProgress(
@@ -140,6 +142,24 @@ export class SplatLoader extends Loader {
               }),
             );
           }
+
+          if ((data as { nextChunk?: boolean }).nextChunk) {
+            let chunk: Uint8Array;
+            if (!readStream) {
+              chunk = new Uint8Array(0);
+            } else {
+              const { done, value } = await readStream.read();
+              if (done) {
+                readStream.releaseLock();
+                readStream = undefined;
+                chunk = new Uint8Array(0);
+              } else {
+                chunk = value;
+              }
+            }
+            worker.call("nextChunk", { chunk });
+          }
+
           // if ((data as { orig?: unknown }).orig) {
           //   if (extSplats) {
           //     initExt = (data as { orig?: unknown }).orig as {
@@ -188,8 +208,8 @@ export class SplatLoader extends Loader {
             fileBytes: fileBytes?.slice(),
             fileType,
             pathName: resolvedURL || fileName,
-            stream,
-            streamLength,
+            chunked: stream !== undefined,
+            chunkedLength: streamLength,
             encoding: packedSplats?.splatEncoding,
             lod,
             lodBase,

--- a/src/SplatMesh.ts
+++ b/src/SplatMesh.ts
@@ -275,6 +275,7 @@ export class SplatMesh extends SplatGenerator {
   editable: boolean;
   raycastable: boolean;
   minRaycastOpacity: number;
+  raycastIndices?: { numSplats: number; indices: Uint32Array };
   // Compiled SplatEdits for applying SDF edits to splat RGBA + centers
   rgbaDisplaceEdits: SplatEdits | null = null;
   // Optional RgbaArray to overwrite splat RGBA values with custom values.
@@ -287,7 +288,6 @@ export class SplatMesh extends SplatGenerator {
 
   enableLod?: boolean;
   lodScale: number;
-  outsideFoveate?: number;
   behindFoveate?: number;
   coneFov0?: number;
   coneFov?: number;
@@ -388,7 +388,6 @@ export class SplatMesh extends SplatGenerator {
 
     this.enableLod = options.enableLod;
     this.lodScale = options.lodScale ?? 1.0;
-    this.outsideFoveate = undefined;
     this.behindFoveate = options.behindFoveate;
     this.coneFov0 = options.coneFov0;
     this.coneFov = options.coneFov;
@@ -850,6 +849,25 @@ export class SplatMesh extends SplatGenerator {
 
     let updated = false;
 
+    const lodSplats = this.packedSplats?.lodSplats ?? this.extSplats?.lodSplats;
+    this.context.enableLod.value = lodSplats != null && lodIndices != null;
+    if (this.enableLod === false) {
+      this.context.enableLod.value = false;
+    }
+    this.context.lodIndices.value = lodIndices?.texture ?? emptyLodIndices;
+
+    if (this.context.enableLod.value && lodSplats) {
+      this.context.splats = lodSplats;
+      this.numSplats = lodIndices?.numSplats ?? 0;
+    }
+
+    this.context.numSplats.value = this.numSplats;
+
+    if (this.context.splats !== this.lastSplats) {
+      this.lastSplats = this.context.splats;
+      this.generatorDirty = true;
+    }
+
     if (!this.covSplats) {
       if (this.context.transform.update(this)) {
         updated = true;
@@ -968,25 +986,6 @@ export class SplatMesh extends SplatGenerator {
       }
     }
 
-    const lodSplats = this.packedSplats?.lodSplats ?? this.extSplats?.lodSplats;
-    this.context.enableLod.value = lodSplats != null && lodIndices != null;
-    if (this.enableLod === false) {
-      this.context.enableLod.value = false;
-    }
-    this.context.lodIndices.value = lodIndices?.texture ?? emptyLodIndices;
-
-    if (this.context.enableLod.value && lodSplats) {
-      this.context.splats = lodSplats;
-      this.numSplats = lodIndices?.numSplats ?? 0;
-    }
-
-    this.context.numSplats.value = this.numSplats;
-
-    if (this.context.splats !== this.lastSplats) {
-      this.lastSplats = this.context.splats;
-      this.generatorDirty = true;
-    }
-
     if (this.generatorDirty) {
       this.constructGenerator(this.context);
       this.generatorDirty = false;
@@ -1012,6 +1011,7 @@ export class SplatMesh extends SplatGenerator {
     }[],
   ) {
     if (
+      !SplatMesh.isStaticInitialized ||
       !this.raycastable ||
       (!this.packedSplats && !this.extSplats && !this.paged)
     ) {
@@ -1033,12 +1033,17 @@ export class SplatMesh extends SplatGenerator {
     let intersections = 0;
 
     const numSplats =
-      (paged ? this.paged?.numSplats : this.context.numSplats.value) ?? 0;
-    const indices = paged
-      ? (this.paged?.dynoIndices.value.image.data as Uint32Array)
-      : this.context.enableLod.value
-        ? (this.context.lodIndices.value.image.data as Uint32Array)
-        : null;
+      this.raycastIndices?.numSplats ??
+      (paged ? this.paged?.numSplats : this.context.numSplats.value) ??
+      0;
+    const indices =
+      this.raycastIndices?.indices ??
+      (paged
+        ? (this.paged?.dynoIndices.value.image.data as Uint32Array)
+        : this.context.enableLod.value
+          ? (this.context.lodIndices.value.image.data as Uint32Array)
+          : null) ??
+      null;
 
     if (!ext) {
       const packed = paged

--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -35,8 +35,12 @@ export class PagedSplats implements SplatSource {
   withCredentials?: boolean;
   fileBytes?: Uint8Array;
   fileType?: SplatFileType;
+
   numSh: number;
   maxSh: number;
+  sh1Codes?: Uint32Array;
+  sh2Codes?: Uint32Array;
+  sh3Codes?: Uint32Array | [Uint32Array, Uint32Array];
 
   numSplats: number;
   splatEncoding?: SplatEncoding;
@@ -94,8 +98,10 @@ export class PagedSplats implements SplatSource {
   }
 
   dispose() {
-    this.dynoIndices.value.dispose();
-    this.dynoIndices.value = SplatPager.emptyIndicesTexture;
+    if (this.dynoIndices.value !== SplatPager.emptyIndicesTexture) {
+      this.dynoIndices.value.dispose();
+      this.dynoIndices.value = SplatPager.emptyIndicesTexture;
+    }
   }
 
   setMaxSh(maxSh: number) {
@@ -233,6 +239,9 @@ export class PagedSplats implements SplatSource {
         const result = (await worker.call("loadPackedSplats", {
           fileBytes: decodeBytes,
           pathName: this.chunkUrl(chunk),
+          sh1Codes: this.sh1Codes?.slice(),
+          sh2Codes: this.sh2Codes?.slice(),
+          sh3Codes: this.sh3Codes?.slice(),
         })) as { lodSplats: PackedResult };
         const lodSplats = result.lodSplats;
         if (!this.splatEncoding) {
@@ -261,12 +270,21 @@ export class PagedSplats implements SplatSource {
             this.splatEncoding.sh3Max ?? 1.0,
           );
         }
+        this.sh1Codes = lodSplats.extra.sh1Codes ?? this.sh1Codes;
+        this.sh2Codes = lodSplats.extra.sh2Codes ?? this.sh2Codes;
+        this.sh3Codes = lodSplats.extra.sh3Codes ?? this.sh3Codes;
         return lodSplats;
       }
 
+      const sh3Codes = this.sh3Codes as [Uint32Array, Uint32Array] | undefined;
       const result = (await worker.call("loadExtSplats", {
         fileBytes: decodeBytes,
         pathName: this.chunkUrl(chunk),
+        sh1Codes: this.sh1Codes?.slice(),
+        sh2Codes: this.sh2Codes?.slice(),
+        sh3Codes: sh3Codes
+          ? [sh3Codes[0].slice(), sh3Codes[1].slice()]
+          : undefined,
       })) as { lodSplats: ExtResult };
       const lodSplats = result.lodSplats;
       if (!this.splatEncoding) {
@@ -280,6 +298,9 @@ export class PagedSplats implements SplatSource {
                 ? 1
                 : 0;
       }
+      this.sh1Codes = lodSplats.extra.sh1Codes ?? this.sh1Codes;
+      this.sh2Codes = lodSplats.extra.sh2Codes ?? this.sh2Codes;
+      this.sh3Codes = lodSplats.extra.sh3Codes ?? this.sh3Codes;
       return lodSplats;
     });
   }

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -95,6 +95,9 @@ export type PackedExtra = {
   sh1?: Uint32Array;
   sh2?: Uint32Array;
   sh3?: Uint32Array;
+  sh1Codes?: Uint32Array;
+  sh2Codes?: Uint32Array;
+  sh3Codes?: Uint32Array;
   lodTree?: Uint32Array;
   radMeta?: RadMeta;
 };
@@ -111,6 +114,9 @@ export type ExtExtra = {
   sh2?: Uint32Array;
   sh3a?: Uint32Array;
   sh3b?: Uint32Array;
+  sh1Codes?: Uint32Array;
+  sh2Codes?: Uint32Array;
+  sh3Codes?: [Uint32Array, Uint32Array];
   lodTree?: Uint32Array;
   radMeta?: RadMeta;
 };

--- a/src/shaders/computeUvec4.glsl
+++ b/src/shaders/computeUvec4.glsl
@@ -20,7 +20,7 @@ out uvec4 target;
 
 {{ GLOBALS }}
 
-void produceSplat(int index) {
+void produceSplat(int _index) {
     {{ STATEMENTS }}
 }
 

--- a/src/shaders/computeUvec4_Vec4.glsl
+++ b/src/shaders/computeUvec4_Vec4.glsl
@@ -21,7 +21,7 @@ layout(location = 1) out vec4 target3;
 
 {{ GLOBALS }}
 
-void produceSplat(int index) {
+void produceSplat(int _index) {
     {{ STATEMENTS }}
 }
 

--- a/src/shaders/computeUvec4x2.glsl
+++ b/src/shaders/computeUvec4x2.glsl
@@ -21,7 +21,7 @@ layout(location = 1) out uvec4 target2;
 
 {{ GLOBALS }}
 
-void produceSplat(int index) {
+void produceSplat(int _index) {
     {{ STATEMENTS }}
 }
 

--- a/src/shaders/computeUvec4x2_Vec4.glsl
+++ b/src/shaders/computeUvec4x2_Vec4.glsl
@@ -25,7 +25,7 @@ layout(location = 2) out vec4 target3;
 
 {{ GLOBALS }}
 
-void produceSplat(int index) {
+void produceSplat(int _index) {
     {{ STATEMENTS }}
 }
 

--- a/src/shaders/computeVec4.glsl
+++ b/src/shaders/computeVec4.glsl
@@ -20,7 +20,7 @@ out vec4 target;
 
 {{ GLOBALS }}
 
-void computeReadback(int index) {
+void computeReadback(int _index) {
     {{ STATEMENTS }}
 }
 

--- a/src/shaders/splatVertex.glsl
+++ b/src/shaders/splatVertex.glsl
@@ -26,6 +26,7 @@ uniform float deltaTime;
 uniform bool debugFlag;
 uniform float minAlpha;
 uniform bool enable2DGS;
+uniform bool lodInflate;
 uniform float blurAmount;
 uniform float preBlurAmount;
 uniform float focalDistance;
@@ -106,6 +107,15 @@ void main() {
     if (rgba.a > 1.0) {
         // Stretch 1..2 to 1..5
         rgba.a = min(rgba.a * 4.0 - 3.0, 5.0);
+
+        if (lodInflate) {
+            // Adjust size to componsate for loss of opacity
+            float opacity = exp((rgba.a * rgba.a - 1.0) / 2.718281828459045);
+            float rescale = pow(opacity, 1.0 / 3.0);
+            scales *= rescale;
+            rgba.a = 1.0;
+        }
+
         // Expand the maximum std dev to approximately cover the larger range
         adjustedStdDev = maxStdDev + 0.7 * (rgba.a - 1.0);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -304,11 +304,6 @@ export function getTransferable(ctx: unknown): Transferable[] {
 
       if (obj instanceof ArrayBuffer) {
         buffers.push(obj);
-      } else if (
-        obj instanceof ReadableStream ||
-        obj instanceof WritableStream
-      ) {
-        buffers.push(obj);
       } else if (ArrayBuffer.isView(obj)) {
         // Handles TypedArrays and DataView
         buffers.push(obj.buffer as ArrayBuffer);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -37,6 +37,7 @@ const rpcHandlers = {
   updateLodTrees,
   traverseLodTrees,
   getLodTreeLevel,
+  nextChunk,
 };
 
 async function onMessage(event: MessageEvent) {
@@ -130,8 +131,8 @@ async function decodeBytesUrl({
   url,
   requestHeader,
   withCredentials,
-  stream,
-  streamLength,
+  chunked,
+  chunkedLength,
   sendStatus,
 }: {
   decoder: ChunkDecoder;
@@ -139,8 +140,8 @@ async function decodeBytesUrl({
   url?: string;
   requestHeader?: Record<string, string>;
   withCredentials?: boolean;
-  stream?: ReadableStream;
-  streamLength?: number;
+  chunked?: boolean;
+  chunkedLength?: number;
   sendStatus: (data: unknown) => void;
 }) {
   if (fileBytes) {
@@ -150,44 +151,56 @@ async function decodeBytesUrl({
         fileBytes.subarray(i, Math.min(i + CHUNK_SIZE, fileBytes.length)),
       );
     }
-  } else if (url || stream) {
-    let readStream: ReadableStreamDefaultReader<Uint8Array>;
-    let total = 0;
+  } else if (url) {
+    const request = new Request(url, {
+      headers: requestHeader ? new Headers(requestHeader) : undefined,
+      credentials: withCredentials ? "include" : "same-origin",
+    });
 
-    if (url) {
-      const request = new Request(url, {
-        headers: requestHeader ? new Headers(requestHeader) : undefined,
-        credentials: withCredentials ? "include" : "same-origin",
-      });
-
-      const response = await fetch(request);
-      if (!response.ok || !response.body) {
-        throw new Error(
-          `Failed to fetch "${url}": ${response.status} ${response.statusText}`,
-        );
-      }
-      readStream = response.body.getReader();
-      const contentLength = Number.parseInt(
-        response.headers.get("Content-Length") || "0",
+    const response = await fetch(request);
+    if (!response.ok || !response.body) {
+      throw new Error(
+        `Failed to fetch "${url}": ${response.status} ${response.statusText}`,
       );
-      total = Number.isNaN(contentLength) ? 0 : contentLength;
-    } else if (stream) {
-      readStream = stream.getReader();
-      total = streamLength ?? 0;
-    } else {
-      throw new Error("No url or stream provided");
     }
+    const readStream = response.body.getReader();
+    const contentLength = Number.parseInt(
+      response.headers.get("Content-Length") || "0",
+    );
+    const total = Number.isNaN(contentLength) ? 0 : contentLength;
     let loaded = 0;
 
     while (true) {
       const { done, value } = await readStream.read();
       if (done) {
+        readStream.releaseLock();
         break;
       }
       loaded += value.length;
       sendStatus({ loaded, total });
 
       decoder.push(value);
+    }
+  } else if (chunked) {
+    let loaded = 0;
+    const total = chunkedLength ?? 0;
+    while (true) {
+      const readNextChunk: Promise<Uint8Array> = new Promise((resolve) => {
+        nextChunkWaiter = resolve;
+      });
+      sendStatus({ nextChunk: true });
+      const nextChunk = await readNextChunk;
+
+      if (nextChunk.length === 0) {
+        break;
+      }
+
+      decoder.push(nextChunk);
+      loaded += nextChunk.length;
+      sendStatus({ progress: { loaded, total } });
+    }
+    if (total === 0) {
+      sendStatus({ progress: { loaded, total: loaded } });
     }
   } else {
     throw new Error("No url or fileBytes provided");
@@ -203,6 +216,9 @@ type DecodedPackedResult = {
   sh1?: Uint32Array;
   sh2?: Uint32Array;
   sh3?: Uint32Array;
+  sh1Codes?: Uint32Array;
+  sh2Codes?: Uint32Array;
+  sh3Codes?: Uint32Array;
   lodTree?: Uint32Array;
   splatEncoding: SplatEncoding;
 };
@@ -215,6 +231,9 @@ function toPackedResult(packed: DecodedPackedResult): PackedResult {
       sh1: packed.sh1,
       sh2: packed.sh2,
       sh3: packed.sh3,
+      sh1Codes: packed.sh1Codes,
+      sh2Codes: packed.sh2Codes,
+      sh3Codes: packed.sh3Codes,
       lodTree: packed.lodTree,
     },
     splatEncoding: packed.splatEncoding,
@@ -229,13 +248,16 @@ async function loadPackedSplats(
     fileBytes,
     fileType,
     pathName,
-    stream,
-    streamLength,
+    chunked,
+    chunkedLength,
     encoding,
     lod,
     lodBase,
     lodAbove,
     nonLod,
+    sh1Codes,
+    sh2Codes,
+    sh3Codes,
   }: {
     url?: string;
     requestHeader?: Record<string, string>;
@@ -243,13 +265,16 @@ async function loadPackedSplats(
     fileBytes?: Uint8Array;
     fileType?: string;
     pathName?: string;
-    stream?: ReadableStream;
-    streamLength?: number;
+    chunked?: boolean;
+    chunkedLength?: number;
     encoding?: SplatEncoding;
     lod?: boolean | "quality";
     lodBase?: number;
     lodAbove?: number;
     nonLod?: boolean;
+    sh1Codes?: Uint32Array;
+    sh2Codes?: Uint32Array;
+    sh3Codes?: Uint32Array;
   },
   {
     sendStatus,
@@ -259,15 +284,22 @@ async function loadPackedSplats(
 ) {
   // console.log("loadPackedSplats", { url, requestHeader, withCredentials, fileBytes, fileType, pathName, stream, streamLength, encoding, lod, lodBase, lodAbove, nonLod });
   if (!lod) {
-    const decoder = decode_to_packedsplats(fileType, pathName ?? url, encoding);
+    const decoder = decode_to_packedsplats(
+      fileType,
+      pathName ?? url,
+      encoding,
+      sh1Codes,
+      sh2Codes,
+      sh3Codes,
+    );
     const decoded = await decodeBytesUrl({
       decoder,
       fileBytes,
       url,
       requestHeader,
       withCredentials,
-      stream,
-      streamLength,
+      chunked,
+      chunkedLength,
       sendStatus,
     });
     const result = toPackedResult(decoded as DecodedPackedResult);
@@ -284,8 +316,8 @@ async function loadPackedSplats(
     url,
     requestHeader,
     withCredentials,
-    stream,
-    streamLength,
+    chunked,
+    chunkedLength,
     sendStatus,
   });
 
@@ -317,6 +349,10 @@ async function loadPackedSplats(
   }
 
   const initialSplats = decoded.len();
+  const lodName = lod === "quality" ? "Bhatt" : "Tiny";
+  console.log(
+    `Loaded ${initialSplats} splats. Starting ${lodName} LoD build...`,
+  );
 
   const lodStart = performance.now();
   if (lod === "quality") {
@@ -329,7 +365,7 @@ async function loadPackedSplats(
   const lodDuration = performance.now() - lodStart;
 
   console.log(
-    `${lod === "quality" ? "Bhatt" : "Tiny"} LoD: ${initialSplats} -> ${decoded.len()} (${lodDuration} ms)`,
+    `${lodName} LoD: ${initialSplats} -> ${decoded.len()} (${lodDuration} ms)`,
   );
 
   const lodPacked = decoded.to_packedsplats_lod();
@@ -345,6 +381,9 @@ type DecodedExtResult = {
   sh2?: Uint32Array;
   sh3a?: Uint32Array;
   sh3b?: Uint32Array;
+  sh1Codes?: Uint32Array;
+  sh2Codes?: Uint32Array;
+  sh3Codes?: [Uint32Array, Uint32Array];
   lodTree?: Uint32Array;
 };
 
@@ -357,6 +396,9 @@ function toExtResult(packed: DecodedExtResult): ExtResult {
       sh2: packed.sh2,
       sh3a: packed.sh3a,
       sh3b: packed.sh3b,
+      sh1Codes: packed.sh1Codes,
+      sh2Codes: packed.sh2Codes,
+      sh3Codes: packed.sh3Codes,
       lodTree: packed.lodTree,
     },
   };
@@ -370,12 +412,15 @@ async function loadExtSplats(
     fileBytes,
     fileType,
     pathName,
-    stream,
-    streamLength,
+    chunked,
+    chunkedLength,
     lod,
     lodBase,
     lodAbove,
     nonLod,
+    sh1Codes,
+    sh2Codes,
+    sh3Codes,
   }: {
     url?: string;
     requestHeader?: Record<string, string>;
@@ -383,12 +428,15 @@ async function loadExtSplats(
     fileBytes?: Uint8Array;
     fileType?: string;
     pathName?: string;
-    stream?: ReadableStream;
-    streamLength?: number;
+    chunked?: boolean;
+    chunkedLength?: number;
     lod?: boolean | "quality";
     lodBase?: number;
     lodAbove?: number;
     nonLod?: boolean;
+    sh1Codes?: Uint32Array;
+    sh2Codes?: Uint32Array;
+    sh3Codes?: [Uint32Array, Uint32Array];
   },
   {
     sendStatus,
@@ -398,15 +446,21 @@ async function loadExtSplats(
 ) {
   // console.log("loadExtSplats", { url, requestHeader, withCredentials, fileBytes, fileType, pathName, stream, streamLength, lod, lodBase, lodAbove, nonLod });
   if (!lod) {
-    const decoder = decode_to_extsplats(fileType, pathName ?? url);
+    const decoder = decode_to_extsplats(
+      fileType,
+      pathName ?? url,
+      sh1Codes,
+      sh2Codes,
+      sh3Codes,
+    );
     const decoded = await decodeBytesUrl({
       decoder,
       fileBytes,
       url,
       requestHeader,
       withCredentials,
-      stream,
-      streamLength,
+      chunked,
+      chunkedLength,
       sendStatus,
     });
     const result = toExtResult(decoded as DecodedExtResult);
@@ -423,8 +477,8 @@ async function loadExtSplats(
     url,
     requestHeader,
     withCredentials,
-    stream,
-    streamLength,
+    chunked,
+    chunkedLength,
     sendStatus,
   });
 
@@ -452,6 +506,10 @@ async function loadExtSplats(
   }
 
   const initialSplats = decoded.len();
+  const lodName = lod === "quality" ? "Bhatt" : "Tiny";
+  console.log(
+    `Loaded ${initialSplats} splats. Starting ${lodName} LoD build...`,
+  );
 
   const lodStart = performance.now();
   if (lod === "quality") {
@@ -464,7 +522,7 @@ async function loadExtSplats(
   const lodDuration = performance.now() - lodStart;
 
   console.log(
-    `${lod === "quality" ? "Bhatt" : "Tiny"} LoD: ${initialSplats} -> ${decoded.len()} (${lodDuration} ms)`,
+    `${lodName} LoD: ${initialSplats} -> ${decoded.len()} (${lodDuration} ms)`,
   );
 
   const lodPacked = decoded.to_extsplats_lod();
@@ -674,23 +732,19 @@ function traverseLodTrees({
   maxSplats,
   pixelScaleLimit,
   lastPixelLimit,
-  fovXdegrees,
-  fovYdegrees,
   instances,
 }: {
   maxSplats: number;
   pixelScaleLimit: number;
   lastPixelLimit?: number;
-  fovXdegrees: number;
-  fovYdegrees: number;
   instances: Record<
     string,
     {
+      instanceId: string;
       lodId: number;
       rootPage?: number;
       viewToObjectCols: number[];
       lodScale: number;
-      outsideFoveate: number;
       behindFoveate: number;
       coneFov0: number;
       coneFov: number;
@@ -716,9 +770,6 @@ function traverseLodTrees({
   const lodScales = new Float32Array(
     keyInstances.map(([_key, instance]) => instance.lodScale),
   );
-  const outsideFoveates = new Float32Array(
-    keyInstances.map(([_key, instance]) => instance.outsideFoveate),
-  );
   const behindFoveates = new Float32Array(
     keyInstances.map(([_key, instance]) => instance.behindFoveate),
   );
@@ -732,30 +783,6 @@ function traverseLodTrees({
     keyInstances.map(([_key, instance]) => instance.coneFoveate),
   );
 
-  // console.log(`traverseLodTrees: maxSplats=${maxSplats}, pixelScaleLimit=${pixelScaleLimit}, fovXdegrees=${fovXdegrees}, fovYdegrees=${fovYdegrees}, outsideFoveate=${outsideFoveate}, behindFoveate=${behindFoveate}, lodIds=${lodIds.length}, viewToObjects=${viewToObjects.length}`);
-  // const { instanceIndices, chunks } = traverse_lod_trees(
-  //   maxSplats,
-  //   pixelScaleLimit,
-  //   fovXdegrees,
-  //   fovYdegrees,
-  //   lodIds,
-  //   rootPages,
-  //   viewToObjects,
-  //   lodScales,
-  //   outsideFoveates,
-  //   behindFoveates,
-  //   coneFov0s,
-  //   coneFovs,
-  //   coneFoveates,
-  // ) as {
-  //   instanceIndices: {
-  //     lodId: number;
-  //     numSplats: number;
-  //     indices: Uint32Array;
-  //   }[];
-  //   chunks: [number, number][];
-  // };
-  // const pixelLimit = undefined;
   const result = new_traverse_lod_trees(
     maxSplats,
     pixelScaleLimit,
@@ -793,7 +820,6 @@ function traverseLodTrees({
   // console.log(`traverseLodTrees: chunks=${chunks.length}`, JSON.stringify(chunks));
   return {
     keyIndices: indices,
-    // chunks: chunks.map(([instIndex, chunk]) => [keyInstances[instIndex][0], chunk]),
     chunks,
     pixelLimit,
   };
@@ -809,6 +835,12 @@ function getLodTreeLevel({
   return get_lod_tree_level(lodId, level) as { indices: Uint32Array };
 }
 
+let nextChunkWaiter = (_chunk: Uint8Array) => {};
+
+async function nextChunk({ chunk }: { chunk: Uint8Array }) {
+  nextChunkWaiter(chunk);
+}
+
 // Recursively finds all ArrayBuffers in an object and returns them as an array
 // to use as transferable objects to send between workers.
 function getTransferable(ctx: unknown): Transferable[] {
@@ -820,11 +852,6 @@ function getTransferable(ctx: unknown): Transferable[] {
       seen.add(obj);
 
       if (obj instanceof ArrayBuffer) {
-        buffers.push(obj);
-      } else if (
-        obj instanceof ReadableStream ||
-        obj instanceof WritableStream
-      ) {
         buffers.push(obj);
       } else if (ArrayBuffer.isView(obj)) {
         // Handles TypedArrays and DataView


### PR DESCRIPTION
- 100x faster SplatMesh raycasting (1-3 ms) using a low-resolution LoD sample (10-25K splats), updated with viewpoint and visible splats
- Added Spherical Harmonics clustering to `build-lod` and RAD files, running K-means clustering on up to 64K vectors of SH1-3 values. Clusters are stored at the beginning in RAD chunk 0. Subsequent clusters load uint16 labels per splat, resulting in 50-60% file size savings and faster streaming. Implemented CPU-based (slow, approximate NN search) and GPU-based (default, exhaustive) clustering.
- Added SparkRenderer.lodInflate that toggles "soft" LoD splat mode. When enabled, any splat with opacity>1 will be clamped to 1.0 and inflate in size to compensate, resulting in a more "antialiased" look
- Added SparkRenderer.onDirty() callback for reliable on-demand rendering, allowing you to update/invalidate your render when splat sorting or LoD updates happen. A minimal on-demand render loop can update whenever an input moves the camera or onDirty() is called.
- Added options --cluster-sh, --cluster-sh-cpu, --inflate to build-lod
- Updated examples/editor: Added selectable OpenGL/OpenCV/Z-up coordinate systems, new LoD folder options: Create LoD on load, real-time splat count, foveation parameters, pause/drive LoD updates, lodInflate, foveation cone visualization, page coloring

Minor changes:
- Output "Starting Tiny LoD build..." to console when on-demand LoDing starts
- Renamed compute shader index variable to _index to avoid name collision
- Fixed stream loading on Safari by sending chunks from main thread to decoding worker thread
- Remove obsolete outsideFoveate, fovXdegrees, and fovYdegrees parameters
- Change build-lod default to use --quality mode
- Added SparkXr.moveDirection to move in the XZ plane in the direction you're looking (no up/down movement)
- Added user-selectable THREE.RenderTargetOptions to SparkRenderer.target option, allowing you to render to formats other than RGBA8 for example.
- Added compatibility mode for PlyEncoder that adds properties nx/ny/nz (set to 0.0) that old decoders may need.
- bhatt-lod uses I64Vec3 instead of IVec3 for cell coords