### PR TITLE
improve large coordinate precision issue

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -728,9 +728,7 @@ export class SparkRenderer extends THREE.Mesh {
     geometry.instanceCount = spark.activeSplats;
 
     const accumToWorld = new THREE.Matrix4();
-    if (!this.display.extSplats) {
-      accumToWorld.makeTranslation(spark.display.viewOrigin);
-    }
+    accumToWorld.makeTranslation(spark.display.viewOrigin);
     const cameraToWorld = camera.matrixWorld.clone();
     const worldToCamera = cameraToWorld.invert();
     const accumToCamera = worldToCamera.multiply(accumToWorld);

--- a/src/SplatAccumulator.ts
+++ b/src/SplatAccumulator.ts
@@ -23,6 +23,7 @@ import {
   DynoUsampler2DArray,
   type DynoVal,
   DynoVec3,
+  Gsplat,
   combineCovSplat,
   combineGsplat,
   dynoBlock,
@@ -35,6 +36,7 @@ import {
   outputExtendedSplat,
   outputPackedSplat,
   outputSplatDepth,
+  select,
   splitCovSplat,
   splitGsplat,
   sub,
@@ -65,6 +67,7 @@ export class SplatAccumulator {
   static viewCenterUniform = new DynoVec3({ value: new THREE.Vector3() });
   static viewDirUniform = new DynoVec3({ value: new THREE.Vector3() });
   static sortRadialUniform = new DynoBool({ value: true });
+  static sourceRelativeUniform = new DynoBool({ value: false });
   maxSplats = 0;
   numSplats = 0;
   target: THREE.WebGLArrayRenderTarget | null = null;
@@ -95,8 +98,10 @@ export class SplatAccumulator {
     }
   }
 
-  // Returns a THREE.DataArrayTexture representing the NewSplatAccumulator
-  // content as 2 x Uint32x4 data array textures (2048 x 2048 x 2048 in size)
+  // Returns accumulator backing textures.
+  // Center coordinates stored in these textures are relative to viewOrigin,
+  // not absolute world-space positions. External consumers that decode centers
+  // directly must add display.viewOrigin to reconstruct world-space positions.
   getTextures(): THREE.DataArrayTexture[] {
     if (this.target) {
       return this.target.textures;
@@ -222,6 +227,14 @@ export class SplatAccumulator {
         { index: "int" },
         {},
         ({ index }, _outputs, { roots }) => {
+          let depthGsplat: DynoVal<typeof Gsplat> | undefined;
+          let depthCovSplat: DynoVal<typeof CovSplat> | undefined;
+          const centerOrigin = select(
+            SplatAccumulator.sourceRelativeUniform,
+            dynoConst("vec3", [0, 0, 0]),
+            SplatAccumulator.viewCenterUniform,
+          );
+
           if (generator) {
             generator.inputs.index = index;
           }
@@ -232,18 +245,46 @@ export class SplatAccumulator {
           if (this.extSplats) {
             if (!this.covSplats) {
               if (generator) {
-                const output = outputExtendedSplat(generator.outputs.gsplat);
+                const centerSubView = sub(
+                  splitGsplat(generator.outputs.gsplat).outputs.center,
+                  centerOrigin,
+                );
+                const gsplat = combineGsplat({
+                  gsplat: generator.outputs.gsplat,
+                  center: centerSubView,
+                });
+                depthGsplat = gsplat;
+                const output = outputExtendedSplat(gsplat);
                 roots.push(output);
               } else {
                 throw new Error("Generator must be provided");
               }
             } else {
               if (covGenerator) {
-                const output = outputExtCovSplat(covGenerator.outputs.covsplat);
+                const centerSubView = sub(
+                  splitCovSplat(covGenerator.outputs.covsplat).outputs.center,
+                  centerOrigin,
+                );
+                const covsplat = combineCovSplat({
+                  covsplat: covGenerator.outputs.covsplat,
+                  center: centerSubView,
+                });
+                depthCovSplat = covsplat;
+                const output = outputExtCovSplat(covsplat);
                 roots.push(output);
               } else if (generator) {
                 const covsplat = gsplatToCovSplat(generator.outputs.gsplat);
-                const output = outputExtCovSplat(covsplat);
+                const centerSubView = sub(
+                  splitCovSplat(covsplat).outputs.center,
+                  centerOrigin,
+                );
+                depthCovSplat = combineCovSplat({
+                  covsplat,
+                  center: centerSubView,
+                });
+                const output = outputExtCovSplat(
+                  depthCovSplat,
+                );
                 roots.push(output);
               } else {
                 throw new Error("Generator must be provided");
@@ -254,7 +295,7 @@ export class SplatAccumulator {
               if (generator) {
                 const centerSubView = sub(
                   splitGsplat(generator.outputs.gsplat).outputs.center,
-                  SplatAccumulator.viewCenterUniform,
+                  centerOrigin,
                 );
                 // Use expanded LoD opacity encoding
                 const halfAlpha = mul(
@@ -266,6 +307,7 @@ export class SplatAccumulator {
                   center: centerSubView,
                   opacity: halfAlpha,
                 });
+                depthGsplat = gsplat;
                 const output = outputPackedSplat(
                   gsplat,
                   dynoConst("vec4", [0, 1, LN_SCALE_MIN, LN_SCALE_MAX]),
@@ -285,7 +327,7 @@ export class SplatAccumulator {
               }
               const centerSubView = sub(
                 splitCovSplat(covsplat).outputs.center,
-                SplatAccumulator.viewCenterUniform,
+                centerOrigin,
               );
               const halfAlpha = mul(
                 splitCovSplat(covsplat).outputs.opacity,
@@ -296,6 +338,7 @@ export class SplatAccumulator {
                 center: centerSubView,
                 opacity: halfAlpha,
               });
+              depthCovSplat = covsplat;
               const output = outputCovSplat(
                 covsplat,
                 dynoConst("vec4", [0, 1, LN_SCALE_MIN, LN_SCALE_MAX]),
@@ -306,19 +349,19 @@ export class SplatAccumulator {
               throw new Error("Generator must be provided");
             }
           }
-          if (generator) {
+          if (depthGsplat) {
             const outputDepth = outputSplatDepth(
-              generator.outputs.gsplat,
-              SplatAccumulator.viewCenterUniform,
+              depthGsplat,
+              dynoConst('vec3', [0, 0, 0]),
               SplatAccumulator.viewDirUniform,
               SplatAccumulator.sortRadialUniform,
             );
             roots.push(outputDepth);
           }
-          if (covGenerator) {
+          if (depthCovSplat) {
             const outputDepth = outputCovSplatDepth(
-              covGenerator.outputs.covsplat,
-              SplatAccumulator.viewCenterUniform,
+              depthCovSplat,
+              dynoConst('vec3', [0, 0, 0]),
               SplatAccumulator.viewDirUniform,
               SplatAccumulator.sortRadialUniform,
             );
@@ -365,12 +408,14 @@ export class SplatAccumulator {
   generate({
     generator,
     covGenerator,
+    relativeToView,
     base,
     count,
     renderer,
   }: {
     generator?: GsplatGenerator;
     covGenerator?: CovSplatGenerator;
+    relativeToView?: boolean;
     base: number;
     count: number;
     renderer: THREE.WebGLRenderer;
@@ -386,6 +431,7 @@ export class SplatAccumulator {
       generator,
       covGenerator,
     );
+    SplatAccumulator.sourceRelativeUniform.value = relativeToView ?? false;
     program.update();
 
     const renderState = this.saveRenderState(renderer);
@@ -571,10 +617,20 @@ export class SplatAccumulator {
         for (const { node, base, count } of this.mapping) {
           const { generator, covGenerator } = node;
           if ((generator || covGenerator) && count > 0) {
-            this.generate({ generator, covGenerator, base, count, renderer });
+            this.generate({
+              generator,
+              covGenerator,
+              relativeToView: node.generateRelativeToView,
+              base,
+              count,
+              renderer,
+            });
           }
         }
       },
+      // Read back the accumulator contents in their stored representation.
+      // As with getTextures(), decoded centers are relative to this viewOrigin
+      // and must be rebased by callers that need absolute world-space centers.
       readback: async () => {
         const textures = this.getTextures();
         if (this.readbackSplats.length === 0) {

--- a/src/SplatGenerator.ts
+++ b/src/SplatGenerator.ts
@@ -271,6 +271,7 @@ export class SplatGenerator extends THREE.Object3D {
   frameUpdate?: (context: FrameUpdateContext) => void;
   version: number;
   mappingVersion: number;
+  generateRelativeToView: boolean;
 
   constructor({
     numSplats,
@@ -298,6 +299,7 @@ export class SplatGenerator extends THREE.Object3D {
     this.frameUpdate = update;
     this.version = 0;
     this.mappingVersion = 0;
+    this.generateRelativeToView = false;
 
     if (construct) {
       const constructed = construct(this);

--- a/src/SplatMesh.ts
+++ b/src/SplatMesh.ts
@@ -37,8 +37,10 @@ import {
   DynoInt,
   DynoUsampler2D,
   type DynoVal,
+  DynoVec3,
   DynoVec4,
   Gsplat,
+  add,
   combineCovSplat,
   combineGsplat,
   defineGsplat,
@@ -48,6 +50,7 @@ import {
   mul,
   splitCovSplat,
   splitGsplat,
+  sub,
   unindentLines,
 } from "./dyno";
 
@@ -295,6 +298,54 @@ export class SplatMesh extends SplatGenerator {
 
   showLodPage?: number;
   showLodPageDyno = new DynoInt({ value: 0 });
+  private viewOriginDyno = new DynoVec3({ value: new THREE.Vector3() });
+
+  private canGenerateRelativeToView({
+    hasEdits,
+  }: {
+    hasEdits: boolean;
+  }) {
+    return true;
+  }
+
+  private updateRelativeTransform(
+    transform: THREE.Matrix4,
+    viewToWorld: THREE.Matrix4,
+  ) {
+    const relativeTransform = transform.clone();
+    const relativePosition = new THREE.Vector3().setFromMatrixPosition(
+      relativeTransform,
+    );
+    relativePosition.sub(new THREE.Vector3().setFromMatrixPosition(viewToWorld));
+    relativeTransform.setPosition(relativePosition);
+    return relativeTransform;
+  }
+
+  private toWorldGsplat(gsplat: DynoVal<typeof Gsplat>) {
+    const center = add(splitGsplat(gsplat).outputs.center, this.viewOriginDyno);
+    return combineGsplat({ gsplat, center });
+  }
+
+  private fromWorldGsplat(gsplat: DynoVal<typeof Gsplat>) {
+    const center = sub(splitGsplat(gsplat).outputs.center, this.viewOriginDyno);
+    return combineGsplat({ gsplat, center });
+  }
+
+  private toWorldCovSplat(covsplat: DynoVal<typeof CovSplat>) {
+    const center = add(
+      splitCovSplat(covsplat).outputs.center,
+      this.viewOriginDyno,
+    );
+    return combineCovSplat({ covsplat, center });
+  }
+
+  private fromWorldCovSplat(covsplat: DynoVal<typeof CovSplat>) {
+    const center = sub(
+      splitCovSplat(covsplat).outputs.center,
+      this.viewOriginDyno,
+    );
+    return combineCovSplat({ covsplat, center });
+  }
 
   constructor(options: SplatMeshOptions = {}) {
     super({
@@ -707,6 +758,10 @@ export class SplatMesh extends SplatGenerator {
         // Transform from object to world-space
         gsplat = transform.applyGsplat(gsplat);
 
+        if (this.generateRelativeToView && (this.rgbaDisplaceEdits || this.worldModifiers)) {
+          gsplat = this.toWorldGsplat(gsplat);
+        }
+
         // Apply any global recoloring and opacity
         const recolorRgba = mul(recolor, splitGsplat(gsplat).outputs.rgba);
         gsplat = combineGsplat({ gsplat, rgba: recolorRgba });
@@ -721,6 +776,10 @@ export class SplatMesh extends SplatGenerator {
           for (const modifier of this.worldModifiers) {
             gsplat = modifier.apply({ gsplat }).gsplat;
           }
+        }
+
+        if (this.generateRelativeToView && (this.rgbaDisplaceEdits || this.worldModifiers)) {
+          gsplat = this.fromWorldGsplat(gsplat);
         }
 
         // We're done! Output resulting Gsplat
@@ -791,6 +850,10 @@ export class SplatMesh extends SplatGenerator {
         // Transform from object to world-space
         covsplat = covTransform.applyCovSplat(covsplat);
 
+        if (this.generateRelativeToView && (this.rgbaDisplaceEdits || this.covWorldModifiers)) {
+          covsplat = this.toWorldCovSplat(covsplat);
+        }
+
         // Apply any global recoloring and opacity
         const recolorRgba = mul(recolor, splitCovSplat(covsplat).outputs.rgba);
         covsplat = combineCovSplat({ covsplat, rgba: recolorRgba });
@@ -805,6 +868,10 @@ export class SplatMesh extends SplatGenerator {
           for (const modifier of this.covWorldModifiers) {
             covsplat = modifier.apply({ covsplat }).covsplat;
           }
+        }
+
+        if (this.generateRelativeToView && (this.rgbaDisplaceEdits || this.covWorldModifiers)) {
+          covsplat = this.fromWorldCovSplat(covsplat);
         }
 
         // We're done! Output resulting Gsplat
@@ -868,8 +935,25 @@ export class SplatMesh extends SplatGenerator {
       this.generatorDirty = true;
     }
 
+    const viewOrigin = new THREE.Vector3().setFromMatrixPosition(viewToWorld);
+    if (!viewOrigin.equals(this.viewOriginDyno.value)) {
+      this.viewOriginDyno.value.copy(viewOrigin);
+      updated = true;
+    }
+
+    const generateRelativeToView = this.canGenerateRelativeToView({
+      hasEdits: false,
+    });
+    if (this.generateRelativeToView !== generateRelativeToView) {
+      this.generateRelativeToView = generateRelativeToView;
+      updated = true;
+    }
+
     if (!this.covSplats) {
-      if (this.context.transform.update(this)) {
+      const transformMatrix = this.generateRelativeToView
+        ? this.updateRelativeTransform(this.matrixWorld, viewToWorld)
+        : this.matrixWorld;
+      if (this.context.transform.updateFromMatrix(transformMatrix)) {
         updated = true;
       }
 
@@ -887,12 +971,7 @@ export class SplatMesh extends SplatGenerator {
         updated = true;
       }
 
-      const objectToWorld = new THREE.Matrix4().compose(
-        this.context.transform.translate.value,
-        this.context.transform.rotate.value,
-        new THREE.Vector3().setScalar(this.context.transform.scale.value),
-      );
-      const worldToObject = objectToWorld.invert();
+      const worldToObject = this.matrixWorld.clone().invert();
       const viewToObjectMatrix = worldToObject.multiply(viewToWorld);
       if (
         this.context.viewToObject.updateFromMatrix(viewToObjectMatrix) &&
@@ -902,7 +981,10 @@ export class SplatMesh extends SplatGenerator {
         updated = true;
       }
     } else {
-      if (this.context.covTransform.update(this)) {
+      const covTransformMatrix = this.generateRelativeToView
+        ? this.updateRelativeTransform(this.matrixWorld, viewToWorld)
+        : this.matrixWorld;
+      if (this.context.covTransform.updateFromMatrix(covTransformMatrix)) {
         updated = true;
       }
 


### PR DESCRIPTION
Relate to https://github.com/sparkjsdev/spark/issues/287

## Summary

Improve far-from-origin precision for transformed `SplatMesh` scenes by rebasing internal splat generation, accumulation, and sorting to view-relative coordinates.

Internally, splat centers are no longer propagated as long-lived absolute world-space values by default. The pipeline now prefers centers relative to the current `viewOrigin` / accumulator origin and only converts back to world space where external semantics require it.

## What Changed

- Rebased accumulator output to `viewOrigin` for both packed and extended splat paths
- Updated depth sorting to use rebased centers
- Applied render-time origin restoration consistently in `SparkRenderer`
- Added support for generators that already emit view-relative centers
- Rebased `SplatMesh` generation before large world translations lose precision