### PR TITLE
Auto-build WASM packages on npm install via prepare hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check . --fix",
     "lint:summary": "biome check --reporter=summary",
-    "prepare": "",
+    "prepare": "npm run build:wasm",
     "site:build:relativeurls": "npm run build && npm run site:clean && node scripts/copy-site-files.js && mkdocs build && node scripts/rename-assets-to-static.js && node scripts/replace-urls.js",
     "site:build": "npm run build && npm run site:clean && node scripts/copy-site-files.js && mkdocs build && node scripts/rename-assets-to-static.js",
     "site:clean": "node scripts/clean-site-files.js && node scripts/clean-site.js",


### PR DESCRIPTION
After cloning the repo and running `npm install`, the `npm run build` command fails with this error:

```
[vite]: Rollup failed to resolve import "spark-rs" from "src/SplatPager.ts".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to build.rollupOptions.external.
```

(fresh clone on osx with cargo 1.94.1 and npm 11.8.0)

The error message suggests a Vite/Rollup config issue, but the real problem is that the `spark-rs` and `spark-worker-rs` WASM packages haven't been built yet. Their `pkg/` directories are gitignored (correctly), but nothing in the standard setup flow builds them automatically. You have to know to run `npm run build:wasm` first, which is only mentioned in the README's build instructions in passing.

## Fix
This PR sets the `prepare` script in `package.json` to `npm run build:wasm`. The `prepare` hook runs automatically after `npm install`, so the WASM packages are built before anything else needs them. This means `npm install && npm run build` just works out of the box for new contributors.

The WASM build is only triggered by `npm install` — not on every `npm run build` — so there's no performance cost during normal development iteration.

## Verification
- Delete `rust/spark-rs/pkg` and `rust/spark-worker-rs/pkg`
- Run `npm install` — verify WASM packages are built automatically
- Run `npm run build` — verify it completes successfully