### PR TITLE
Specify 0.180.0 or higher as Three.js peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "fflate": "^0.8.2"
   },
   "peerDependencies": {
-    "three": "^0.180.0"
+    "three": ">=0.180.0"
   },
   "keywords": ["3d", "three.js", "gsplats", "3dgs", "gaussian", "splats"]
 }


### PR DESCRIPTION
Fixes #308 

The three peer dependency is currently constrained to `0.180.X`, whereas the intended constraint is r181 or higher. This PR changes the package.json to reflect this. While future Three.js versions might break things, introducing an upper bound is likely going to cause more issues and would require updating this every month.
