### PR TITLE
Add missing "three/addons" entry to importmap of splat-dissolve-effects example

### DIFF
--- a/examples/splat-dissolve-effects/index.html
+++ b/examples/splat-dissolve-effects/index.html
@@ -17,6 +17,7 @@
     {
       "imports": {
         "three": "/examples/js/vendor/three/build/three.module.js",
+        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "/dist/spark.module.js"
       }
     }


### PR DESCRIPTION
The hosted version of the `splat-dissolve-effects` is currently broken due to a missing import map entry. Opening https://sparkjs.dev/examples/#splat-dissolve-effects logs the following error in the console:
> Uncaught TypeError: The specifier “three/addons/controls/OrbitControls.js” was a bare specifier, but was not remapped to anything. Relative module specifiers must start with “./”, “../” or “/”.

When using `npm run dev` the error does not show up as Vite ignores the importmap and is able to properly resolve the `three/addon/` import.

This PR adds the missing entry to the importmap of the example, resolving the issue.