### PR TITLE
Fix incorrect numSplats in lod-on-demand example

### DIFF
--- a/examples/lod-on-demand/index.html
+++ b/examples/lod-on-demand/index.html
@@ -68,7 +68,7 @@
 
     function newColors() {
       const modulate = new THREE.Color(Math.random(), Math.random(), Math.random());
-      const array = new Uint8ClampedArray(splats.numSplats * 4);
+      const array = new Uint8ClampedArray(splats.packedSplats.numSplats * 4);
       splats.forEachSplat((index, center, scales, quaternion, opacity, color) => {
         array[index * 4] = color.r * modulate.r * 255;
         array[index * 4 + 1] = color.g * modulate.g * 255;
@@ -101,7 +101,7 @@
         alert("Create LoD splats first!");
       }
     });
-    gui.add(spark, "lodSplatCount", 10000, 200000, 10000).name("LoD splat count");
+    gui.add(spark, "lodSplatCount", 10000, 600000, 10000).name("LoD splat count");
 
     const controls = new SparkControls({ canvas: renderer.domElement });
 


### PR DESCRIPTION
When pressing the _"Change non-LoD splat colors"_ button while the LoD splats were being shown, only a subset of the underlying splat colours were changed. This was caused by the fact that `SplatMesh.numSplats` reflects the number of splats being rendered with LoD enabled ([SplatMesh#L861](https://github.com/sparkjsdev/spark/blob/915c474795e0c78f7cd1b7f4eb97695028b495c0/src/SplatMesh.ts#L861)), not the total amount of splats in the mesh.
<img width="1496" height="1220" alt="image" src="https://github.com/user-attachments/assets/39015fe0-97a4-4e87-9af2-316541e8ce49" />

This PR also increases the upper bound for the `lodSplatCount` slider. This way the user can increase it all the way up to the number of splats of the original splat file. Before the example always showed a reduced LoD version, even when cranking up the amount. Worst case this could lead people to believe an inherent reduction in visual quality when enabling/generating LoD.