### PR TITLE
Save and restore activeCubeFace and activeMipmapLevel when rendering to render target

### DIFF
--- a/src/SplatAccumulator.ts
+++ b/src/SplatAccumulator.ts
@@ -186,6 +186,8 @@ export class SplatAccumulator {
   private saveRenderState(renderer: THREE.WebGLRenderer) {
     return {
       target: renderer.getRenderTarget(),
+      activeCubeFace: renderer.getActiveCubeFace(),
+      activeMipmapLevel: renderer.getActiveMipmapLevel(),
       xrEnabled: renderer.xr.enabled,
       autoClear: renderer.autoClear,
     };
@@ -195,11 +197,17 @@ export class SplatAccumulator {
     renderer: THREE.WebGLRenderer,
     state: {
       target: THREE.WebGLRenderTarget | null;
+      activeCubeFace: number;
+      activeMipmapLevel: number;
       xrEnabled: boolean;
       autoClear: boolean;
     },
   ) {
-    renderer.setRenderTarget(state.target);
+    renderer.setRenderTarget(
+      state.target,
+      state.activeCubeFace,
+      state.activeMipmapLevel,
+    );
     renderer.xr.enabled = state.xrEnabled;
     renderer.autoClear = state.autoClear;
   }


### PR DESCRIPTION
The `SplatAccumulator` saves and restore the current render state. However, for the render target it only recorded the target itself and not the active cube face or active mipmap level. This caused a regression in the [envMap example](https://sparkjs.dev/examples/#envmap), where the resulting envmap does not have all its faces rendered, as can be seen by the "black" reflected in the duck model.

It would be nicer if `SparkRenderer.renderCubeMap` could ensure that the splats are only updated once, instead of once per cube face. That said, this bugfix would still be needed in any situation where the current render target has a non-zero cube face or mipmap level.