### PR TITLE
fix: fire setDirty when pager fetch pipeline drains

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -1233,6 +1233,7 @@ export class SparkRenderer extends THREE.Mesh {
           extSplats: this.pagedExtSplats,
           maxSplats: this.maxPagedSplats,
           numFetchers: this.numLodFetchers,
+          onDirty: () => this.setDirty(),
         });
 
         const { lodId } = (await worker.call("newLodTree", {

--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -1233,7 +1233,7 @@ export class SparkRenderer extends THREE.Mesh {
           extSplats: this.pagedExtSplats,
           maxSplats: this.maxPagedSplats,
           numFetchers: this.numLodFetchers,
-          onDirty: () => this.setDirty(),
+          onLodTreeUpdate: () => this.setDirty(),
         });
 
         const { lodId } = (await worker.call("newLodTree", {

--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -462,6 +462,7 @@ export interface SplatPagerOptions {
    * @default 3
    */
   numFetchers?: number;
+  onDirty?: () => void;
 }
 
 export class SplatPager {
@@ -478,6 +479,7 @@ export class SplatPager {
   autoDrive: boolean;
   numFetchers: number;
   fetchPause = 0;
+  onDirty?: () => void;
 
   splatsChunkToPage: Map<
     PagedSplats,
@@ -573,6 +575,7 @@ export class SplatPager {
 
     this.autoDrive = options.autoDrive ?? true;
     this.numFetchers = options.numFetchers ?? 3;
+    this.onDirty = options.onDirty;
 
     this.splatsChunkToPage = new Map();
     this.pageToSplatsChunk = new Array(this.maxPages);
@@ -1336,11 +1339,14 @@ export class SplatPager {
 
   private processFetched() {
     const now = performance.now();
+    let processed = false;
     while (true) {
       const fetched = this.fetched.shift();
       if (!fetched) {
+        if (processed) this.onDirty?.();
         break;
       }
+      processed = true;
       const { splats, chunk, data } = fetched;
 
       let page = this.allocatePage();

--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -462,7 +462,11 @@ export interface SplatPagerOptions {
    * @default 3
    */
   numFetchers?: number;
-  onDirty?: () => void;
+  /**
+   * Called when the LOD tree gains newly-decoded pages (the fetch queue
+   * drains), so on-demand renderers can request a redraw.
+   */
+  onLodTreeUpdate?: () => void;
 }
 
 export class SplatPager {
@@ -479,7 +483,7 @@ export class SplatPager {
   autoDrive: boolean;
   numFetchers: number;
   fetchPause = 0;
-  onDirty?: () => void;
+  onLodTreeUpdate?: () => void;
 
   splatsChunkToPage: Map<
     PagedSplats,
@@ -575,7 +579,7 @@ export class SplatPager {
 
     this.autoDrive = options.autoDrive ?? true;
     this.numFetchers = options.numFetchers ?? 3;
-    this.onDirty = options.onDirty;
+    this.onLodTreeUpdate = options.onLodTreeUpdate;
 
     this.splatsChunkToPage = new Map();
     this.pageToSplatsChunk = new Array(this.maxPages);
@@ -1343,7 +1347,7 @@ export class SplatPager {
     while (true) {
       const fetched = this.fetched.shift();
       if (!fetched) {
-        if (processed) this.onDirty?.();
+        if (processed) this.onLodTreeUpdate?.();
         break;
       }
       processed = true;


### PR DESCRIPTION
## Problem

Fixes #298.

When `SparkRenderer` is used in an on-demand rendering architecture (render only when `onDirty` fires, no continuous loop) with a static camera, paged LOD splats can stop loading partway through. The `onDirty` chain has a gap: chunk fetches complete asynchronously, outside any render frame, and nothing calls `setDirty()` to signal that new data is ready.

## Root cause

`setDirty()` is only called from:
1. After sort completes (`driveSort`)
2. When the LOD snapshot changes (`updateInternal`)
3. After `updateLodInstances` when `lodDirty = true` (`driveLod`)

All three require a render frame to be in progress. If the camera is static and `dirty = false`, `onBeforeRender` never fires → `driveLod` never runs → `consumeLodTreeUpdates` is never called → downloaded chunks sit in `lodTreeUpdates` forever.

## Fix

Add an optional `onDirty` callback to `SplatPagerOptions` and call it when `processFetched()` fully empties the `fetched` queue — i.e. after each chunk finishes decoding and is moved into the LOD pipeline. `SparkRenderer` passes `() => this.setDirty()` when constructing the pager.

This fires after **every individual chunk** lands, giving progressive rendering. The `consumeLodTreeUpdates` path is intentionally unchanged — `SparkRenderer` already calls `setDirty()` via the `lodDirty` flow when it processes those updates inside a render frame.

## Changes

- `SplatPagerOptions`: add optional `onDirty?: () => void`
- `SplatPager`: store callback, call it when `processFetched()` drains `fetched` to empty
- `SparkRenderer`: pass `() => this.setDirty()` when constructing the pager

## Verified

Confirmed against an on-demand renderer that previously required a polling workaround to drive rendering during paged LOD loading. With this fix the workaround is no longer needed.

 — Claude