### PR TITLE
fix: recreate data textures to fix memory leak in case of scene should be disposed

### DIFF
--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -826,34 +826,46 @@ export class SplatPager {
     this.autoDrive = false;
     this.numFetchers = 0;
 
-    this.packedTexture.value.dispose();
+    const packedTexture = this.packedTexture.value;
+    packedTexture.dispose();
+    this.packedTexture.value = SplatPager.emptyPackedTexture;
+
     if (this.extTexture.value !== SplatPager.emptyExtTexture) {
       this.extTexture.value.dispose();
     }
+    this.extTexture.value = SplatPager.emptyExtTexture;
 
     if (!this.extSplats) {
       if (this.sh1Texture.value !== SplatPager.emptySh1Texture) {
         this.sh1Texture.value.dispose();
       }
+      this.sh1Texture.value = SplatPager.emptySh1Texture;
       if (this.sh2Texture.value !== SplatPager.emptySh2Texture) {
         this.sh2Texture.value.dispose();
       }
+      this.sh2Texture.value = SplatPager.emptySh2Texture;
       if (this.sh3Texture.value !== SplatPager.emptySh3Texture) {
         this.sh3Texture.value.dispose();
       }
+      this.sh3Texture.value = SplatPager.emptySh3Texture;
+      this.sh3TextureB.value = SplatPager.emptyExtSh3BTexture;
     } else {
       if (this.sh1Texture.value !== SplatPager.emptyExtSh1Texture) {
         this.sh1Texture.value.dispose();
       }
+      this.sh1Texture.value = SplatPager.emptyExtSh1Texture;
       if (this.sh2Texture.value !== SplatPager.emptyExtSh2Texture) {
         this.sh2Texture.value.dispose();
       }
+      this.sh2Texture.value = SplatPager.emptyExtSh2Texture;
       if (this.sh3Texture.value !== SplatPager.emptyExtSh3Texture) {
         this.sh3Texture.value.dispose();
       }
+      this.sh3Texture.value = SplatPager.emptyExtSh3Texture;
       if (this.sh3TextureB.value !== SplatPager.emptyExtSh3BTexture) {
         this.sh3TextureB.value.dispose();
       }
+      this.sh3TextureB.value = SplatPager.emptyExtSh3BTexture;
     }
   }
 


### PR DESCRIPTION
fixes #286 

## Stale links to old Data Textures in Dyno fix

Just recreation of DataTexture links on every dispose to prevent storing it after SparkPager.dispose() called

## Steps to check:

1. create SplatRenderer and load first scene via SplatMesh
2. dispose SplatRenderer and SplatMesh
3. look at heap memory, mind a memory value
4. repeat 1..3: memory value should not to grow