### PR TITLE
Fix broken example in README.md and document removed SparkRenderer injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,16 @@ Copy the following code into an `index.html` file.
 </script>
 <script type="module">
   import * as THREE from "three";
-  import { SplatMesh } from "@sparkjsdev/spark";
+  import { SparkRenderer, SplatMesh } from "@sparkjsdev/spark";
 
   const scene = new THREE.Scene();
-  const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+  const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 1000);
   const renderer = new THREE.WebGLRenderer();
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement)
+
+  const spark = new SparkRenderer({ renderer });
+  scene.add(spark);
 
   const splatURL = "https://sparkjs.dev/assets/splats/butterfly.spz";
   const butterfly = new SplatMesh({ url: splatURL });
@@ -81,10 +84,6 @@ Copy the following code into an `index.html` file.
   });
 </script>
 ```
-
-### Web Editor
-
-Remix the [glitch starter template](https://glitch.com/edit/#!/sparkjs-dev)
 
 ### CDN
 

--- a/docs/docs/0.1-2.0-migration-guide.md
+++ b/docs/docs/0.1-2.0-migration-guide.md
@@ -26,6 +26,13 @@ Spark 2.0 was designed with backward-compatibility in mind. We expect most 0.1 a
 </script>
 ```
 
+## Creation of the SparkRenderer
+In Spark 0.1 you didn't have to manually create a `SparkRenderer` as Spark would automatically inject one into your scene. Spark 2.0 requires you to create one and add it to your scene, otherwise no splats will be rendered.
+```javascript
+const spark = new SparkRenderer({ renderer });
+scene.add(spark);
+```
+
 ## Multiple viewpoints and renderers
 
 In Spark 0.1 you created multiple viewpoint from a single `SparkRenderer` instance by calling `.newViewpoint()` on it, returning a `SparkViewpoint`. This representation stored 1 global set of RGBA splats and N splat rendering orders for a viewpoint for correct back-to-front rendering and blending. This model made it impossible to have different colored splats, for example RGBA splats + depth-colored, or rendering different sets of splats with different shader effects applied, or different directional lighting from spherical harmonics from different vantage points.
@@ -113,7 +120,7 @@ Spark 2.0 supports SOGS files via a `.zip` file with `manifest.json` and referen
 
 ## Temporary fallback: OldSparkRenderer
 
-If all else fails, the original `SparkRenderer` class from Spark 0.1 has been renamed to `OldSparkRenderer` (and other classes similarly like `OldSparkViewpoint`). Rename your `new SparkRenderer()` calls to `new OldSparkRenderer()`, and make sure to explicitly add your `OldSparkRenderer` to your scene because only the new `SparkRenderer` will be automatically injected.
+If all else fails, the original `SparkRenderer` class from Spark 0.1 has been renamed to `OldSparkRenderer` (and other classes similarly like `OldSparkViewpoint`). Rename your `new SparkRenderer()` calls to `new OldSparkRenderer()`, and make sure to explicitly add your `OldSparkRenderer` to your scene because it won't be automatically injected.
 
 We expect to unwind and remove this support over time and hope you will be able to migrate to the new renderer!
 


### PR DESCRIPTION
Fixes #303

This PR fixes a couple things:

- Update the "Getting Started" example to match the "Getting Started" code in the docs
- Remove the "Web Editor" section as Glitch is no longer operational
- Introduce a section in the migration guide to mention that `SparkRenderer` creation/injection no longer happens automatically (see ef5061c176475152a408e109cdbb516042412a7d)
- Updated working that implied the new `SparkRenderer` would be automatically injected into the scene. 