### PR TITLE
SplatPager: null texture source to ensure underlying arrays can be GC'ed

### DIFF
--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -827,32 +827,41 @@ export class SplatPager {
     this.numFetchers = 0;
 
     this.packedTexture.value.dispose();
+    this.packedTexture.value.source.data = null;
     if (this.extTexture.value !== SplatPager.emptyExtTexture) {
       this.extTexture.value.dispose();
+      this.extTexture.value.source.data = null;
     }
 
     if (!this.extSplats) {
       if (this.sh1Texture.value !== SplatPager.emptySh1Texture) {
         this.sh1Texture.value.dispose();
+        this.sh1Texture.value.source.data = null;
       }
       if (this.sh2Texture.value !== SplatPager.emptySh2Texture) {
         this.sh2Texture.value.dispose();
+        this.sh2Texture.value.source.data = null;
       }
       if (this.sh3Texture.value !== SplatPager.emptySh3Texture) {
         this.sh3Texture.value.dispose();
+        this.sh3Texture.value.source.data = null;
       }
     } else {
       if (this.sh1Texture.value !== SplatPager.emptyExtSh1Texture) {
         this.sh1Texture.value.dispose();
+        this.sh1Texture.value.source.data = null;
       }
       if (this.sh2Texture.value !== SplatPager.emptyExtSh2Texture) {
         this.sh2Texture.value.dispose();
+        this.sh2Texture.value.source.data = null;
       }
       if (this.sh3Texture.value !== SplatPager.emptyExtSh3Texture) {
         this.sh3Texture.value.dispose();
+        this.sh3Texture.value.source.data = null;
       }
       if (this.sh3TextureB.value !== SplatPager.emptyExtSh3BTexture) {
         this.sh3TextureB.value.dispose();
+        this.sh3TextureB.value.source.data = null;
       }
     }
   }


### PR DESCRIPTION
Alternative PR to #320 that nulls the texture source data. This removes all references to the underlying TypedArrays instead of only clearing the reference from `SplatPager -> Texture`. Since these textures are also referenced from (cached) shader materials, this avoids having to [hunt them down manually](https://github.com/sparkjsdev/spark/pull/320#issuecomment-4327227356).

Ultimately it's still a crude approach, but at least ensures no large memory leaks occur. A proper solution would be to ensure that the cached shader materials are disposed of. This way no references to the textures should remain, allowing them to GC'ed normally.