### PR TITLE
Externalize three/addons from bundle

### DIFF
--- a/src/SplatAccumulator.ts
+++ b/src/SplatAccumulator.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { FullScreenQuad } from "three/examples/jsm/postprocessing/Pass.js";
+import { FullScreenQuad } from "three/addons/postprocessing/Pass.js";
 import { Readback } from "./Readback";
 import { SplatEdit } from "./SplatEdit";
 import {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -127,7 +127,7 @@ export default defineConfig(({ mode }) => {
       },
       sourcemap: true,
       rollupOptions: {
-        external: ["three"],
+        external: ["three", /^three\/addons/],
         output: {
           globals: {
             three: "THREE",


### PR DESCRIPTION
Imports from `three/addons` were not treated as external during build, meaning the final bundle included things like `FullScreenQuad`. This PR simply expands the external list with a regex matching anything imported from `three/addons`. Helps a bit with reducing the bundle size (#321)
