### PR TITLE
Ignore obj_info header lines in PLY files

### DIFF
--- a/rust/spark-lib/src/ply.rs
+++ b/rust/spark-lib/src/ply.rs
@@ -381,7 +381,7 @@ fn parse_header(header: &str) -> anyhow::Result<ParsedHeader> {
                     return Err(anyhow!("Unsupported PLY version: {}", fields[2]));
                 }
             },
-            "comment" => {
+            "comment" | "obj_info" => {
                 // ignore
             },
             "element" if fields.len() == 3 => {


### PR DESCRIPTION
The `PlyDecoder` errors upon encountering an unknown/unsupported line in the header. This includes `obj_info`, which servers a similar purpose to `comment`. This PR simply treats "obj_info" the same way as "comment" ensuring .ply files with such lines can be loaded.

See #329 for additional context.