### PR TITLE
Fix broken example links

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -285,7 +285,8 @@
           iframe.src = path;
 
           if (codeButton) {
-            codeButton.href = `https://github.com/sparkjsdev/spark/blob/main${path}`;
+            const sourcePath = path.replace(/^\.\//, "");
+            codeButton.href = `https://github.com/sparkjsdev/spark/blob/main/examples/${sourcePath}`;
           }
 
           if (fullPageButton) {

--- a/examples.html
+++ b/examples.html
@@ -285,8 +285,7 @@
           iframe.src = path;
 
           if (codeButton) {
-            const sourcePath = path.replace(/^\.\//, "");
-            codeButton.href = `https://github.com/sparkjsdev/spark/blob/main/examples/${sourcePath}`;
+            codeButton.href = `https://github.com/sparkjsdev/spark/blob/main/examples/${path}`;
           }
 
           if (fullPageButton) {

--- a/examples.html
+++ b/examples.html
@@ -285,7 +285,7 @@
           iframe.src = path;
 
           if (codeButton) {
-            codeButton.href = `https://github.com/sparkjsdev/spark/blob/main/examples/${path}`;
+            codeButton.href = new URL(`https://github.com/sparkjsdev/spark/blob/main/examples/${path}`).toString();
           }
 
           if (fullPageButton) {


### PR DESCRIPTION
For any example if you click the code link it leads to a broken page.

e.g. https://sparkjs.dev/examples/#particle-simulation