### PR TITLE
Include three/addons/ in importmaps and switch to jsdelivr CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Copy the following code into an `index.html` file.
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/three.module.js",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+      "three/addons/": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/examples/jsm/",
       "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.0.0/spark.module.js"
     }
   }
@@ -91,7 +92,8 @@ Copy the following code into an `index.html` file.
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/three.module.js",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
       "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.0.0/spark.module.js"
      }
   }

--- a/docs/docs/0.1-2.0-migration-guide.md
+++ b/docs/docs/0.1-2.0-migration-guide.md
@@ -19,7 +19,8 @@ Spark 2.0 was designed with backward-compatibility in mind. We expect most 0.1 a
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/three.module.js",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
       "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.0.0/spark.module.js"
     }
   }

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -9,7 +9,8 @@ Copy and paste code below in an `index.html` file or remix in the [Web Playgroun
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/three.module.js",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
       "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.0.0/spark.module.js"
     }
   }

--- a/examples/basic-xr/index.html
+++ b/examples/basic-xr/index.html
@@ -19,9 +19,10 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/three.module.js",
-        "lil-gui": "https://cdn.jsdelivr.net/npm/lil-gui@0.20.0/+esm",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/debug-color/index.html
+++ b/examples/debug-color/index.html
@@ -20,6 +20,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/depth-of-field/index.html
+++ b/examples/depth-of-field/index.html
@@ -20,8 +20,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/dynamic-lighting/index.html
+++ b/examples/dynamic-lighting/index.html
@@ -68,8 +68,9 @@
   <script type="importmap">
   {
     "imports": {
-      "three": "../js/vendor/three/build/three.module.js",
-      "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js"
     }
   }
   </script>

--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -55,9 +55,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
-        "@sparkjsdev/spark": "/dist/spark.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/envmap/index.html
+++ b/examples/envmap/index.html
@@ -33,7 +33,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/extsplats/index.html
+++ b/examples/extsplats/index.html
@@ -21,6 +21,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/glsl/index.html
+++ b/examples/glsl/index.html
@@ -20,6 +20,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/hello-world/index.html
+++ b/examples/hello-world/index.html
@@ -17,6 +17,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/interactive-deform/index.html
+++ b/examples/interactive-deform/index.html
@@ -35,10 +35,10 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "/examples/js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
-        "@sparkjsdev/spark": "/dist/spark.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js"
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/interactive-holes/index.html
+++ b/examples/interactive-holes/index.html
@@ -35,9 +35,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/interactivity/index.html
+++ b/examples/interactivity/index.html
@@ -25,7 +25,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/lod-on-demand/index.html
+++ b/examples/lod-on-demand/index.html
@@ -27,8 +27,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/lod/index.html
+++ b/examples/lod/index.html
@@ -17,27 +17,17 @@
 </head>
 
 <body>
-  <!-- <script type="importmap">
-    {
-      "imports": {
-        "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.179.0/three.module.js",
-        "lil-gui": "https://cdn.jsdelivr.net/npm/lil-gui@0.20.0/+esm",
-        "@sparkjsdev/spark": "./spark.module.js"
-      }
-    }
-  </script> -->
   <script src="https://cdn.jsdelivr.net/npm/stats.js@0.17.0/build/stats.min.js"></script>
-  <!-- <script src="/node_modules/stats.js/build/stats.min.js"></script> -->
   <script type="importmap">
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>
-  <!-- "@sparkjsdev/spark": "./spark.module.js" -->
   <script type="module">
     import * as THREE from "three";
     import { SparkRenderer, OldSparkRenderer, SplatMesh, PackedSplats, SplatLoader, SparkControls, isMobile, SplatEdit, SplatEditSdf, SplatEditSdfType } from "@sparkjsdev/spark";

--- a/examples/lofi/index.html
+++ b/examples/lofi/index.html
@@ -30,9 +30,10 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/three.module.js",
-        "lil-gui": "https://cdn.jsdelivr.net/npm/lil-gui@0.20.0/+esm",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/mobile-joystick/index.html
+++ b/examples/mobile-joystick/index.html
@@ -37,8 +37,10 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.179.0/three.module.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/multi-lod/index.html
+++ b/examples/multi-lod/index.html
@@ -21,8 +21,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/multiple-splats/index.html
+++ b/examples/multiple-splats/index.html
@@ -28,7 +28,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/multiple-viewpoints/index.html
+++ b/examples/multiple-viewpoints/index.html
@@ -18,7 +18,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/newportal/index.html
+++ b/examples/newportal/index.html
@@ -19,9 +19,10 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/three.module.js",
-        "lil-gui": "https://cdn.jsdelivr.net/npm/lil-gui@0.20.0/+esm",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/nonlod/index.html
+++ b/examples/nonlod/index.html
@@ -21,8 +21,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/particle-animation/index.html
+++ b/examples/particle-animation/index.html
@@ -25,8 +25,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/particle-simulation/index.html
+++ b/examples/particle-simulation/index.html
@@ -20,8 +20,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/portal/index.html
+++ b/examples/portal/index.html
@@ -19,9 +19,10 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/three.module.js",
-        "lil-gui": "https://cdn.jsdelivr.net/npm/lil-gui@0.20.0/+esm",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/procedural-splats/index.html
+++ b/examples/procedural-splats/index.html
@@ -20,6 +20,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/raycasting/index.html
+++ b/examples/raycasting/index.html
@@ -27,6 +27,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/render-cube-depth/index.html
+++ b/examples/render-cube-depth/index.html
@@ -33,7 +33,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/sogs/index.html
+++ b/examples/sogs/index.html
@@ -17,7 +17,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/splat-dissolve-effects/index.html
+++ b/examples/splat-dissolve-effects/index.html
@@ -16,9 +16,9 @@
 	<script type="importmap">
     {
       "imports": {
-        "three": "/examples/js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
-        "@sparkjsdev/spark": "/dist/spark.module.js"
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }
   </script>

--- a/examples/splat-flow/index.html
+++ b/examples/splat-flow/index.html
@@ -15,8 +15,9 @@
       {
         "imports": {
           "three": "../js/vendor/three/build/three.module.js",
-          "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-          "@sparkjsdev/spark": "../../dist/spark.module.js"
+          "three/addons/": "../js/vendor/three/examples/jsm/",
+          "@sparkjsdev/spark": "../../dist/spark.module.js",
+          "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
         }
       }
     </script>

--- a/examples/splat-painter/index.html
+++ b/examples/splat-painter/index.html
@@ -48,9 +48,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/splat-reveal-effects/index.html
+++ b/examples/splat-reveal-effects/index.html
@@ -20,8 +20,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/splat-shader-effects/index.html
+++ b/examples/splat-shader-effects/index.html
@@ -15,8 +15,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/splat-texture/index.html
+++ b/examples/splat-texture/index.html
@@ -20,8 +20,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/splat-transitions/index.html
+++ b/examples/splat-transitions/index.html
@@ -14,8 +14,8 @@
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
         "three/addons/": "../js/vendor/three/examples/jsm/",
-        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/stochastic/index.html
+++ b/examples/stochastic/index.html
@@ -17,6 +17,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/streaming-lod/index.html
+++ b/examples/streaming-lod/index.html
@@ -31,8 +31,9 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
-        "lil-gui": "/examples/js/vendor/lil-gui/dist/lil-gui.esm.js",
-        "@sparkjsdev/spark": "../../dist/spark.module.js"
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js",
+        "lil-gui": "../js/vendor/lil-gui/dist/lil-gui.esm.js"
       }
     }
   </script>

--- a/examples/viewer/index.html
+++ b/examples/viewer/index.html
@@ -177,8 +177,8 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "/examples/js/vendor/three/build/three.module.js",
-        "three/addons/": "/examples/js/vendor/three/examples/jsm/",
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }

--- a/examples/webxr/index.html
+++ b/examples/webxr/index.html
@@ -17,6 +17,7 @@
     {
       "imports": {
         "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
         "@sparkjsdev/spark": "../../dist/spark.module.js"
       }
     }


### PR DESCRIPTION
With #336 the bundle expects to be able to resolve imports from `three/addons/`. However, not all examples included `three/addons/` in their importmap, causing them to be broken on the deployed website.

This PR updates all importmaps across examples and documentation to ensure they include both `three` and `three/addons/` as per the [installation instructions](https://threejs.org/manual/#en/installation) of Three.js. Additionally, since cdnjs does not expose the `examples` folder of Three.js, the CDN was switched to jsdelivr. Users would have to do this either way as soon as they wanted to use any of the Three.js addons themselves.

Note: an alternative solution would be to vendor the `Pass.js` file from Three.js so that the spark bundle doesn't import from `three/addons/` directly.

@dmarcos The current process for docs and examples feels brittle. When testing changes to the examples locally, Vite handles the resolving and ignores the importmap, hiding any issues.