### PR TITLE
Remove spark-internal-rs from biome.json ignore list

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,6 @@
       "rust/javascript",
       "rust/spark-worker-rs/pkg",
       "rust/spark-rs/pkg",
-      "rust/spark-internal-rs/pkg",
       "src/vrButton.ts",
       "site",
       "site-repo",


### PR DESCRIPTION
Commit https://github.com/sparkjsdev/spark/commit/3615e9d11978dc53fd4607ff88c1fc22765e389e added `rust/spark-internal-rs/pkg` to the ignore list in `biome.json`. However the `spark-internal-rs` package has been renamed to `spark-worker-rs` as part of https://github.com/sparkjsdev/spark/pull/270.

This PR removes the entry again. If biome does find stale files their and complains, these should be removed manually to resolve the issue. Alternatively we could consider ignoring the entire `rust/` folder, as it's unlikely biome is going to find any file there it should lint/format.

@dmarcos Any reason we shouldn't just ignore the entire `rust/` folder in biome.json?