### PR TITLE
Rename packed to packedData as Chrome 149 onwards considers it a reserved keyword

### DIFF
--- a/src/ExtSplats.ts
+++ b/src/ExtSplats.ts
@@ -779,10 +779,10 @@ export class DynoExtSplats extends DynoUniform<
 }
 
 export const defineEvaluateExtSH1 = unindent(`
-  vec3 evaluateExtSH1(uvec4 packed, vec3 viewDir) {
-    vec3 sh1_0 = decodeExtRgb(packed.x);
-    vec3 sh1_1 = decodeExtRgb(packed.y);
-    vec3 sh1_2 = decodeExtRgb(packed.z);
+  vec3 evaluateExtSH1(uvec4 packedData, vec3 viewDir) {
+    vec3 sh1_0 = decodeExtRgb(packedData.x);
+    vec3 sh1_1 = decodeExtRgb(packedData.y);
+    vec3 sh1_2 = decodeExtRgb(packedData.z);
 
     return sh1_0 * (-0.4886025 * viewDir.y)
       + sh1_1 * (0.4886025 * viewDir.z)

--- a/src/PackedSplats.ts
+++ b/src/PackedSplats.ts
@@ -1069,22 +1069,22 @@ export class DynoPackedSplats extends DynoUniform<
 }
 
 export const defineEvalPackedSH1 = unindent(`
-  vec3 evaluatePackedSH1(uvec2 packed, vec3 viewDir, float sh1Max) {
+  vec3 evaluatePackedSH1(uvec2 packedData, vec3 viewDir, float sh1Max) {
     // Extract sint7 values packed into 2 x uint32
     vec3 sh1_0 = vec3(ivec3(
-      int(packed.x << 25u) >> 25,
-      int(packed.x << 18u) >> 25,
-      int(packed.x << 11u) >> 25
+      int(packedData.x << 25u) >> 25,
+      int(packedData.x << 18u) >> 25,
+      int(packedData.x << 11u) >> 25
     ));
     vec3 sh1_1 = vec3(ivec3(
-      int(packed.x << 4u) >> 25,
-      int((packed.x >> 3u) | (packed.y << 29u)) >> 25,
-      int(packed.y << 22u) >> 25
+      int(packedData.x << 4u) >> 25,
+      int((packedData.x >> 3u) | (packedData.y << 29u)) >> 25,
+      int(packedData.y << 22u) >> 25
     ));
     vec3 sh1_2 = vec3(ivec3(
-      int(packed.y << 15u) >> 25,
-      int(packed.y << 8u) >> 25,
-      int(packed.y << 1u) >> 25
+      int(packedData.y << 15u) >> 25,
+      int(packedData.y << 8u) >> 25,
+      int(packedData.y << 1u) >> 25
     ));
 
     vec3 rgb = sh1_0 * (-0.4886025 * viewDir.y)
@@ -1095,32 +1095,32 @@ export const defineEvalPackedSH1 = unindent(`
 `);
 
 export const defineEvalPackedSH2 = unindent(`
-  vec3 evaluatePackedSH2(uvec4 packed, vec3 viewDir, float sh2Max) {
+  vec3 evaluatePackedSH2(uvec4 packedData, vec3 viewDir, float sh2Max) {
     // Extract sint8 values packed into 4 x uint32
     vec3 sh2_0 = vec3(ivec3(
-      int(packed.x << 24u) >> 24,
-      int(packed.x << 16u) >> 24,
-      int(packed.x << 8u) >> 24
+      int(packedData.x << 24u) >> 24,
+      int(packedData.x << 16u) >> 24,
+      int(packedData.x << 8u) >> 24
     ));
     vec3 sh2_1 = vec3(ivec3(
-      int(packed.x) >> 24,
-      int(packed.y << 24u) >> 24,
-      int(packed.y << 16u) >> 24
+      int(packedData.x) >> 24,
+      int(packedData.y << 24u) >> 24,
+      int(packedData.y << 16u) >> 24
     ));
     vec3 sh2_2 = vec3(ivec3(
-      int(packed.y << 8u) >> 24,
-      int(packed.y) >> 24,
-      int(packed.z << 24u) >> 24
+      int(packedData.y << 8u) >> 24,
+      int(packedData.y) >> 24,
+      int(packedData.z << 24u) >> 24
     ));
     vec3 sh2_3 = vec3(ivec3(
-      int(packed.z << 16u) >> 24,
-      int(packed.z << 8u) >> 24,
-      int(packed.z) >> 24
+      int(packedData.z << 16u) >> 24,
+      int(packedData.z << 8u) >> 24,
+      int(packedData.z) >> 24
     ));
     vec3 sh2_4 = vec3(ivec3(
-      int(packed.w << 24u) >> 24,
-      int(packed.w << 16u) >> 24,
-      int(packed.w << 8u) >> 24
+      int(packedData.w << 24u) >> 24,
+      int(packedData.w << 16u) >> 24,
+      int(packedData.w << 8u) >> 24
     ));
 
     vec3 rgb = sh2_0 * (1.0925484 * viewDir.x * viewDir.y)
@@ -1133,42 +1133,42 @@ export const defineEvalPackedSH2 = unindent(`
 `);
 
 export const defineEvalPackedSH3 = unindent(`
-  vec3 evaluatePackedSH3(uvec4 packed, vec3 viewDir, float sh3Max) {
+  vec3 evaluatePackedSH3(uvec4 packedData, vec3 viewDir, float sh3Max) {
     // Extract sint6 values packed into 4 x uint32
     vec3 sh3_0 = vec3(ivec3(
-      int(packed.x << 26u) >> 26,
-      int(packed.x << 20u) >> 26,
-      int(packed.x << 14u) >> 26
+      int(packedData.x << 26u) >> 26,
+      int(packedData.x << 20u) >> 26,
+      int(packedData.x << 14u) >> 26
     ));
     vec3 sh3_1 = vec3(ivec3(
-      int(packed.x << 8u) >> 26,
-      int(packed.x << 2u) >> 26,
-      int((packed.x >> 4u) | (packed.y << 28u)) >> 26
+      int(packedData.x << 8u) >> 26,
+      int(packedData.x << 2u) >> 26,
+      int((packedData.x >> 4u) | (packedData.y << 28u)) >> 26
     ));
     vec3 sh3_2 = vec3(ivec3(
-      int(packed.y << 22u) >> 26,
-      int(packed.y << 16u) >> 26,
-      int(packed.y << 10u) >> 26
+      int(packedData.y << 22u) >> 26,
+      int(packedData.y << 16u) >> 26,
+      int(packedData.y << 10u) >> 26
     ));
     vec3 sh3_3 = vec3(ivec3(
-      int(packed.y << 4u) >> 26,
-      int((packed.y >> 2u) | (packed.z << 30u)) >> 26,
-      int(packed.z << 24u) >> 26
+      int(packedData.y << 4u) >> 26,
+      int((packedData.y >> 2u) | (packedData.z << 30u)) >> 26,
+      int(packedData.z << 24u) >> 26
     ));
     vec3 sh3_4 = vec3(ivec3(
-      int(packed.z << 18u) >> 26,
-      int(packed.z << 12u) >> 26,
-      int(packed.z << 6u) >> 26
+      int(packedData.z << 18u) >> 26,
+      int(packedData.z << 12u) >> 26,
+      int(packedData.z << 6u) >> 26
     ));
     vec3 sh3_5 = vec3(ivec3(
-      int(packed.z) >> 26,
-      int(packed.w << 26u) >> 26,
-      int(packed.w << 20u) >> 26
+      int(packedData.z) >> 26,
+      int(packedData.w << 26u) >> 26,
+      int(packedData.w << 20u) >> 26
     ));
     vec3 sh3_6 = vec3(ivec3(
-      int(packed.w << 14u) >> 26,
-      int(packed.w << 8u) >> 26,
-      int(packed.w << 2u) >> 26
+      int(packedData.w << 14u) >> 26,
+      int(packedData.w << 8u) >> 26,
+      int(packedData.w << 2u) >> 26
     ));
 
     float xx = viewDir.x * viewDir.x;

--- a/src/SplatAccumulator.ts
+++ b/src/SplatAccumulator.ts
@@ -618,31 +618,31 @@ export class SplatAccumulator {
                   return unindentLines(`
                     int indexDiv8 = ${inputs.index} >> 3;
                     ivec3 coord = splatTexCoord(indexDiv8);
-                    uvec4 packed;
+                    uvec4 packedData;
                     if ((${inputs.index} & 4) == 0) {
-                      packed = texelFetch(${inputs.extSplats1}, coord, 0);
+                      packedData = texelFetch(${inputs.extSplats1}, coord, 0);
                     } else {
-                      packed = texelFetch(${inputs.extSplats2}, coord, 0);
+                      packedData = texelFetch(${inputs.extSplats2}, coord, 0);
                     }
 
                     int indexMod4 = ${inputs.index} & 3;
-                    uint data = (indexMod4 == 0) ? packed.x
-                      : (indexMod4 == 1) ? packed.y
-                      : (indexMod4 == 2) ? packed.z
-                      : packed.w;
+                    uint data = (indexMod4 == 0) ? packedData.x
+                      : (indexMod4 == 1) ? packedData.y
+                      : (indexMod4 == 2) ? packedData.z
+                      : packedData.w;
                     ${outputs.rgba8} = uintToVec4(data);
                   `);
                 }
                 return unindentLines(`
                   int indexDiv4 = ${inputs.index} >> 2;
                   ivec3 coord = splatTexCoord(indexDiv4);
-                  uvec4 packed = texelFetch(${inputs.extSplats1}, coord, 0);
+                  uvec4 packedData = texelFetch(${inputs.extSplats1}, coord, 0);
 
                   int indexMod4 = ${inputs.index} & 3;
-                  uint data = (indexMod4 == 0) ? packed.x
-                    : (indexMod4 == 1) ? packed.y
-                    : (indexMod4 == 2) ? packed.z
-                    : packed.w;
+                  uint data = (indexMod4 == 0) ? packedData.x
+                    : (indexMod4 == 1) ? packedData.y
+                    : (indexMod4 == 2) ? packedData.z
+                    : packedData.w;
                   ${outputs.rgba8} = uintToVec4(data);
                 `);
               },

--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -725,9 +725,9 @@ export class SplatPager {
             dyno.unindentLines(`
             int index = ${inputs.index};
             ivec3 splatCoord = pagedSplatTexCoord(index);
-            uvec4 packed = texelFetch(${inputs.packedTexture}, splatCoord, 0);
+            uvec4 packedData = texelFetch(${inputs.packedTexture}, splatCoord, 0);
 
-            unpackSplatEncoding(packed, ${outputs.gsplat}.center, ${outputs.gsplat}.scales, ${outputs.gsplat}.quaternion, ${outputs.gsplat}.rgba, ${inputs.rgbMinMaxLnScaleMinMax});
+            unpackSplatEncoding(packedData, ${outputs.gsplat}.center, ${outputs.gsplat}.scales, ${outputs.gsplat}.quaternion, ${outputs.gsplat}.rgba, ${inputs.rgbMinMaxLnScaleMinMax});
             if ((${outputs.gsplat}.rgba.a == 0.0) || all(equal(${outputs.gsplat}.scales, vec3(0.0, 0.0, 0.0)))) {
               return;
             }

--- a/src/dyno/splats.ts
+++ b/src/dyno/splats.ts
@@ -190,8 +190,8 @@ export class NumPackedSplats extends UnaryOp<
 const defineReadPackedArray = unindent(`
   bool readPackedArray(usampler2DArray texture, int numSplats, vec4 rgbMinMaxLnScaleMinMax, int index, out Gsplat gsplat) {
     if ((index >= 0) && (index < numSplats)) {
-      uvec4 packed = texelFetch(texture, splatTexCoord(index), 0);
-      unpackSplatEncoding(packed, gsplat.center, gsplat.scales, gsplat.quaternion, gsplat.rgba, rgbMinMaxLnScaleMinMax);
+      uvec4 packedData = texelFetch(texture, splatTexCoord(index), 0);
+      unpackSplatEncoding(packedData, gsplat.center, gsplat.scales, gsplat.quaternion, gsplat.rgba, rgbMinMaxLnScaleMinMax);
       return true;
     } else {
       return false;

--- a/src/shaders/oldSplatVertex.glsl
+++ b/src/shaders/oldSplatVertex.glsl
@@ -61,11 +61,11 @@ void main() {
             splatIndex >> SPLAT_TEX_LAYER_BITS
         );
     }
-    uvec4 packed = texelFetch(packedSplats, texCoord, 0);
+    uvec4 packedData = texelFetch(packedSplats, texCoord, 0);
 
     vec3 center, scales;
     vec4 quaternion, rgba;
-    unpackSplatEncoding(packed, center, scales, quaternion, rgba, rgbMinMaxLnScaleMinMax);
+    unpackSplatEncoding(packedData, center, scales, quaternion, rgba, rgbMinMaxLnScaleMinMax);
 
     if (rgba.a < minAlpha) {
         return;

--- a/src/shaders/splatDefines.glsl
+++ b/src/shaders/splatDefines.glsl
@@ -207,8 +207,8 @@ uvec4 packSplat(vec3 center, vec3 scales, vec4 quaternion, vec4 rgba) {
     return packSplatEncoding(center, scales, quaternion, rgba, vec4(0.0, 1.0, LN_SCALE_MIN, LN_SCALE_MAX));
 }
 
-void unpackSplatEncoding(uvec4 packed, out vec3 center, out vec3 scales, out vec4 quaternion, out vec4 rgba, vec4 rgbMinMaxLnScaleMinMax) {
-    uint word0 = packed.x, word1 = packed.y, word2 = packed.z, word3 = packed.w;
+void unpackSplatEncoding(uvec4 packedData, out vec3 center, out vec3 scales, out vec4 quaternion, out vec4 rgba, vec4 rgbMinMaxLnScaleMinMax) {
+    uint word0 = packedData.x, word1 = packedData.y, word2 = packedData.z, word3 = packedData.w;
 
     uvec4 uRgba = uvec4(word0 & 0xffu, (word0 >> 8u) & 0xffu, (word0 >> 16u) & 0xffu, (word0 >> 24u) & 0xffu);
     float rgbMin = rgbMinMaxLnScaleMinMax.x;
@@ -239,8 +239,8 @@ void unpackSplatEncoding(uvec4 packed, out vec3 center, out vec3 scales, out vec
 }
 
 // Unpack a Gsplat from a uvec4
-void unpackSplat(uvec4 packed, out vec3 center, out vec3 scales, out vec4 quaternion, out vec4 rgba) {
-    unpackSplatEncoding(packed, center, scales, quaternion, rgba, vec4(0.0, 1.0, LN_SCALE_MIN, LN_SCALE_MAX));
+void unpackSplat(uvec4 packedData, out vec3 center, out vec3 scales, out vec4 quaternion, out vec4 rgba) {
+    unpackSplatEncoding(packedData, center, scales, quaternion, rgba, vec4(0.0, 1.0, LN_SCALE_MIN, LN_SCALE_MAX));
 }
 
 uvec4 packSplatCovEncoding(
@@ -275,8 +275,8 @@ uvec4 packSplatCovEncoding(
     return uvec4(word0, word1, word2, word3);
 }
 
-void unpackSplatCovEncoding(uvec4 packed, out vec3 center, out vec4 rgba, out vec3 xxyyzz, out vec3 xyxzyz, vec4 rgbMinMaxLnScaleMinMax) {
-    uint word0 = packed.x, word1 = packed.y, word2 = packed.z, word3 = packed.w;
+void unpackSplatCovEncoding(uvec4 packedData, out vec3 center, out vec4 rgba, out vec3 xxyyzz, out vec3 xyxzyz, vec4 rgbMinMaxLnScaleMinMax) {
+    uint word0 = packedData.x, word1 = packedData.y, word2 = packedData.z, word3 = packedData.w;
 
     uvec4 uRgba = uvec4(word0 & 0xffu, (word0 >> 8u) & 0xffu, (word0 >> 16u) & 0xffu, (word0 >> 24u) & 0xffu);
     float rgbMin = rgbMinMaxLnScaleMinMax.x;
@@ -306,14 +306,14 @@ void unpackSplatCovEncoding(uvec4 packed, out vec3 center, out vec4 rgba, out ve
 }
 
 void packSplatExtCov(
-    out uvec4 packed, out uvec4 packed2,
+    out uvec4 packedData, out uvec4 packedData2,
     vec3 center, vec4 rgba, vec3 xxyyzz, vec3 xyxzyz
 ) {
-    packed.x = floatBitsToUint(center.x);
-    packed.y = floatBitsToUint(center.y);
-    packed.z = floatBitsToUint(center.z);
-    packed.w = packHalf2x16(vec2(rgba.a, rgba.b));
-    packed2.x = packHalf2x16(rgba.rg);
+    packedData.x = floatBitsToUint(center.x);
+    packedData.y = floatBitsToUint(center.y);
+    packedData.z = floatBitsToUint(center.z);
+    packedData.w = packHalf2x16(vec2(rgba.a, rgba.b));
+    packedData2.x = packHalf2x16(rgba.rg);
 
     vec3 xyxzyzCor = vec3(
         clamp(xyxzyz.x / sqrt(xxyyzz.x * xxyyzz.y), -1.0, 1.0),
@@ -323,26 +323,26 @@ void packSplatExtCov(
     xyxzyzCor = sign(xyxzyzCor) * clamp(log(abs(xyxzyzCor)), -100.0, -0.0000001);
     xxyyzz = log(xxyyzz);
 
-    packed2.y = packHalf2x16(vec2(xxyyzz.x, xxyyzz.y));
-    packed2.z = packHalf2x16(vec2(xxyyzz.z, xyxzyzCor.x));
-    packed2.w = packHalf2x16(vec2(xyxzyzCor.y, xyxzyzCor.z));
+    packedData2.y = packHalf2x16(vec2(xxyyzz.x, xxyyzz.y));
+    packedData2.z = packHalf2x16(vec2(xxyyzz.z, xyxzyzCor.x));
+    packedData2.w = packHalf2x16(vec2(xyxzyzCor.y, xyxzyzCor.z));
 }
 
 void unpackSplatExtCov(
-    uvec4 packed, uvec4 packed2,
+    uvec4 packedData, uvec4 packedData2,
     out vec3 center, out vec4 rgba, out vec3 xxyyzz, out vec3 xyxzyz
 ) {
-    center.x = uintBitsToFloat(packed.x);
-    center.y = uintBitsToFloat(packed.y);
-    center.z = uintBitsToFloat(packed.z);
+    center.x = uintBitsToFloat(packedData.x);
+    center.y = uintBitsToFloat(packedData.y);
+    center.z = uintBitsToFloat(packedData.z);
 
-    vec2 ab = unpackHalf2x16(packed.w);
-    vec2 rg = unpackHalf2x16(packed2.x);
+    vec2 ab = unpackHalf2x16(packedData.w);
+    vec2 rg = unpackHalf2x16(packedData2.x);
     rgba = vec4(rg, ab.y, ab.x);
 
-    vec2 xxyy = unpackHalf2x16(packed2.y);
-    vec2 zzxy = unpackHalf2x16(packed2.z);
-    vec2 xzyz = unpackHalf2x16(packed2.w);
+    vec2 xxyy = unpackHalf2x16(packedData2.y);
+    vec2 zzxy = unpackHalf2x16(packedData2.z);
+    vec2 xzyz = unpackHalf2x16(packedData2.w);
     xxyyzz = exp(vec3(xxyy.x, xxyy.y, zzxy.x));
     xyxzyz = vec3(zzxy.y, xzyz.x, xzyz.y);
     xyxzyz = -sign(xyxzyz) * exp(-abs(xyxzyz));
@@ -354,48 +354,48 @@ void unpackSplatExtCov(
 }
 
 void packSplatExt(
-    out uvec4 packed, out uvec4 packed2,
+    out uvec4 packedData, out uvec4 packedData2,
     vec3 center, vec3 scales, vec4 quaternion, vec4 rgba
 ) {
-    packed.x = floatBitsToUint(center.x);
-    packed.y = floatBitsToUint(center.y);
-    packed.z = floatBitsToUint(center.z);
-    packed.w = packHalf2x16(vec2(rgba.a, 0.0));
+    packedData.x = floatBitsToUint(center.x);
+    packedData.y = floatBitsToUint(center.y);
+    packedData.z = floatBitsToUint(center.z);
+    packedData.w = packHalf2x16(vec2(rgba.a, 0.0));
 
-    packed2.x = packHalf2x16(rgba.rg);
-    packed2.y = packHalf2x16(vec2(rgba.b, log(scales.x)));
-    packed2.z = packHalf2x16(log(scales.yz));
-    packed2.w = encodeQuatOctXy1010R12(quaternion);
+    packedData2.x = packHalf2x16(rgba.rg);
+    packedData2.y = packHalf2x16(vec2(rgba.b, log(scales.x)));
+    packedData2.z = packHalf2x16(log(scales.yz));
+    packedData2.w = encodeQuatOctXy1010R12(quaternion);
 }
 
-vec4 unpackSplatExtCenterAlpha(uvec4 packed) {
+vec4 unpackSplatExtCenterAlpha(uvec4 packedData) {
     return vec4(
-        uintBitsToFloat(packed.x),
-        uintBitsToFloat(packed.y),
-        uintBitsToFloat(packed.z),
-        unpackHalf2x16(packed.w).x
+        uintBitsToFloat(packedData.x),
+        uintBitsToFloat(packedData.y),
+        uintBitsToFloat(packedData.z),
+        unpackHalf2x16(packedData.w).x
     );
 }
 
-float unpackSplatExtAlpha(uvec4 packed) {
-    return unpackHalf2x16(packed.w).x;
+float unpackSplatExtAlpha(uvec4 packedData) {
+    return unpackHalf2x16(packedData.w).x;
 }
 
 void unpackSplatExt(
-    uvec4 packed, uvec4 packed2,
+    uvec4 packedData, uvec4 packedData2,
     out vec3 center, out vec3 scales, out vec4 quaternion, out vec4 rgba
 ) {
-    center.x = uintBitsToFloat(packed.x);
-    center.y = uintBitsToFloat(packed.y);
-    center.z = uintBitsToFloat(packed.z);
-    rgba.a = unpackHalf2x16(packed.w).x;
+    center.x = uintBitsToFloat(packedData.x);
+    center.y = uintBitsToFloat(packedData.y);
+    center.z = uintBitsToFloat(packedData.z);
+    rgba.a = unpackHalf2x16(packedData.w).x;
 
-    rgba.rg = unpackHalf2x16(packed2.x);
-    vec2 split = unpackHalf2x16(packed2.y);
+    rgba.rg = unpackHalf2x16(packedData2.x);
+    vec2 split = unpackHalf2x16(packedData2.y);
     rgba.b = split.x;
     scales.x = exp(split.y);
-    scales.yz = exp(unpackHalf2x16(packed2.z));
-    quaternion = decodeQuatOctXy1010R12(packed2.w);
+    scales.yz = exp(unpackHalf2x16(packedData2.z));
+    quaternion = decodeQuatOctXy1010R12(packedData2.w);
 }
 
 uint encodeExtRgb(vec3 rgb) {

--- a/src/shaders/splatVertex.glsl
+++ b/src/shaders/splatVertex.glsl
@@ -83,15 +83,15 @@ void main() {
             }
         }
     } else {
-        uvec4 packed = texelFetch(extSplats, texCoord, 0);
+        uvec4 packedData = texelFetch(extSplats, texCoord, 0);
         if (!enableCovSplats) {
-            unpackSplatEncoding(packed, center, scales, quaternion, rgba, vec4(0.0, 1.0, LN_SCALE_MIN, LN_SCALE_MAX));
+            unpackSplatEncoding(packedData, center, scales, quaternion, rgba, vec4(0.0, 1.0, LN_SCALE_MIN, LN_SCALE_MAX));
             zeroScales = equal(scales, vec3(0.0));
             if (all(zeroScales)) {
                 return;
             }
         } else {
-            unpackSplatCovEncoding(packed, center, rgba, xxyyzz, xyxzyz, vec4(0.0, 1.0, LN_SCALE_MIN, LN_SCALE_MAX));
+            unpackSplatCovEncoding(packedData, center, rgba, xxyyzz, xyxzyz, vec4(0.0, 1.0, LN_SCALE_MIN, LN_SCALE_MAX));
             if (all(equal(xxyyzz, vec3(0.0))) && all(equal(xyxzyz, vec3(0.0)))) {
                 return;
             }


### PR DESCRIPTION
See #346 

Essentially ANGLE started considering `packed` a reserved keyword. This change will be part of Chrome 149 and onwards. Spark uses `packed` as an identifier throughout its shaders, so existing experiences will break. This PR renames all instance to `packedData`.