### PR TITLE
Fix incorrect importmap in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Copy the following code into an `index.html` file.
   {
     "imports": {
       "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
-      "three/addons/": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.180.0/examples/jsm/",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
       "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.1.0/spark.module.js"
     }
   }


### PR DESCRIPTION
The changes in #349 didn't change the CDN for one of the entries in the importmap in the README.md example. The example in the Getting Started documentation was correct. This PR fixes the importmap entry. @dmarcos 