### PR TITLE
Check for WEBGL_provoking_vertex extension

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -567,6 +567,16 @@ export class SparkRenderer extends THREE.Mesh {
     this.accumulators.push(new SplatAccumulator(accumulatorOptions));
     this.accumulators.push(new SplatAccumulator(accumulatorOptions));
 
+    // Check if the provoking vertex convention should be changed
+    const provokingVertexExt = this.renderer
+      .getContext()
+      .getExtension("WEBGL_provoking_vertex");
+    if (provokingVertexExt) {
+      provokingVertexExt.provokingVertexWEBGL(
+        provokingVertexExt.FIRST_VERTEX_CONVENTION_WEBGL,
+      );
+    }
+
     if (options.target) {
       const {
         width,


### PR DESCRIPTION
Depending on the exact system configuration, the preferred provoking vertex convention might differ from the WebGL/OpenGL default. This can be communicated by the browser by exposing the `WEBGL_provoking_vertex` extension. In other words, the presence of this extension itself indicates it's worth changing the provoking vertex. This PR checks for the extension and sets `FIRST_VERTEX_CONVENTION_WEBGL` if present.

Going by the Web3D survey data (https://web3dsurvey.com/webgl2/extensions/WEBGL_provoking_vertex) this is relevant for the vast majority of Windows and Mac and iOS devices. Testing on a Windows laptop did show a really nice jump in performance.

This only applies when using `flat` interpolation in shaders, which Spark does. Since these values should be the same for each vertex, changing the provoking vertex makes no semantic difference. That said, it is a global configuration, meaning other uses might be impacted if they rely on `flat` interpolation picking the last vertex.