### PR TITLE
Fix build-lod SH degree clamping logic

### DIFF
--- a/rust/build-lod/src/main.rs
+++ b/rust/build-lod/src/main.rs
@@ -159,8 +159,8 @@ fn process_file_lod_tsplat<TS: SplatReceiver + TsplatArray + SplatGetter>(filena
     }
 
     if let Some(max_sh) = options.max_sh {
-        splats.set_max_sh_degree(max_sh);
-        description.insert("max_sh_degree".to_string(), serde_json::Value::Number(max_sh.into()));
+        splats.clamp_sh_degree(max_sh);
+        description.insert("clamp_sh_degree".to_string(), serde_json::Value::Number(max_sh.into()));
     }
 
     if let Some(min_box) = options.min_box {
@@ -242,7 +242,9 @@ fn process_file_lod_tsplat<TS: SplatReceiver + TsplatArray + SplatGetter>(filena
     let chunk_duration = start_time.elapsed();
     description.insert("chunk_duration".to_string(), serde_json::Number::from_f64(chunk_duration.as_secs_f64()).into());
 
-    let num_sh = TsplatArray::max_sh_degree(&splats).min(options.max_sh.unwrap_or(3));
+    let num_sh = TsplatArray::max_sh_degree(&splats);
+    description.insert("max_sh_degree".to_string(), serde_json::Value::Number(num_sh.into()));
+    
     let mut sh_clusters = None;
     if let Some(num_iterations) = options.cluster_sh {
         if num_sh > 0 {

--- a/rust/spark-lib/src/csplat.rs
+++ b/rust/spark-lib/src/csplat.rs
@@ -163,9 +163,9 @@ impl TsplatArray for CsplatArray {
         self.max_sh_degree
     }
 
-    fn set_max_sh_degree(&mut self, max_sh_degree: usize) {
+    fn clamp_sh_degree(&mut self, max_sh_degree: usize) {
         assert!(max_sh_degree <= 3, "SH degrees must be between 0 and 3");
-        self.max_sh_degree = max_sh_degree;
+        let max_sh_degree = max_sh_degree.min(self.max_sh_degree);
 
         if max_sh_degree < 3 {
             self.sh3.clear();
@@ -176,6 +176,7 @@ impl TsplatArray for CsplatArray {
         if max_sh_degree < 1 {
             self.sh1.clear();
         }
+        self.max_sh_degree = max_sh_degree;
     }
 
     fn len(&self) -> usize {

--- a/rust/spark-lib/src/gsplat.rs
+++ b/rust/spark-lib/src/gsplat.rs
@@ -253,9 +253,9 @@ impl TsplatArray for GsplatArray {
         self.max_sh_degree
     }
 
-    fn set_max_sh_degree(&mut self, max_sh_degree: usize) {
+    fn clamp_sh_degree(&mut self, max_sh_degree: usize) {
         assert!(max_sh_degree <= 3, "SH degrees must be between 0 and 3");
-        self.max_sh_degree = max_sh_degree;
+        let max_sh_degree = max_sh_degree.min(self.max_sh_degree);
 
         if max_sh_degree < 3 {
             self.sh3.clear();
@@ -266,6 +266,7 @@ impl TsplatArray for GsplatArray {
         if max_sh_degree < 1 {
             self.sh1.clear();
         }
+        self.max_sh_degree = max_sh_degree;
     }
 
     fn len(&self) -> usize {

--- a/rust/spark-lib/src/tsplat.rs
+++ b/rust/spark-lib/src/tsplat.rs
@@ -66,7 +66,7 @@ pub trait TsplatArray {
     fn new_capacity(capacity: usize, max_sh_degree: usize) -> Self;
 
     fn max_sh_degree(&self) -> usize;
-    fn set_max_sh_degree(&mut self, max_sh_degree: usize);
+    fn clamp_sh_degree(&mut self, max_sh_degree: usize);
 
     fn len(&self) -> usize;
     fn get(&self, index: usize) -> Self::Splat<'_>;


### PR DESCRIPTION
Renamed confusing `set_max_sh_degree` to better `clamp_sh_degree` and fix logic. Added the clamping vs. final max_sh_degree to the RAD file annotations.

This fixes #352 . Tested for both Gsplat and Csplat on SOG files with fewer degrees than the max-sh cmdline setting.