### PR TITLE
Extract U32 texture data upload logic and restore pixelStorei parameters

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -20,6 +20,7 @@ import {
   isMobile,
   isOculus,
   isVisionPro,
+  uploadU32DataTextureRows,
 } from "./utils";
 
 export interface SparkRendererOptions {
@@ -1084,34 +1085,16 @@ export class SparkRenderer extends THREE.Mesh {
       this.orderingTexture = orderingTexture;
     } else {
       const renderer = this.renderer;
-      const gl = renderer.getContext() as WebGL2RenderingContext;
       if (!renderer.properties.has(this.orderingTexture)) {
         this.orderingTexture.needsUpdate = true;
       } else {
-        const props = renderer.properties.get(this.orderingTexture) as {
-          __webglTexture: WebGLTexture;
-        };
-        const glTexture = props.__webglTexture;
-        if (!glTexture) {
-          throw new Error("ordering texture not found");
-        }
-        renderer.state.activeTexture(gl.TEXTURE0);
-        renderer.state.bindTexture(gl.TEXTURE_2D, glTexture);
-        gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
-        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-        gl.texSubImage2D(
-          gl.TEXTURE_2D,
-          0,
-          0,
-          0,
+        uploadU32DataTextureRows(
+          renderer,
+          this.orderingTexture,
           4096,
           rows,
-          gl.RGBA_INTEGER,
-          gl.UNSIGNED_INT,
-          // data,
           result.ordering,
         );
-        renderer.state.bindTexture(gl.TEXTURE_2D, null);
       }
     }
 

--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -16,7 +16,12 @@ import {
   SplatFileType,
 } from "./defines";
 import { type DynoUsampler2DArray, pagedSplatTexCoord } from "./dyno";
-import { decodeExtSplat, getTextureSize, unpackSplat } from "./utils";
+import {
+  decodeExtSplat,
+  getTextureSize,
+  unpackSplat,
+  uploadU32DataTextureRows,
+} from "./utils";
 import * as wasm from "./wasm";
 
 export interface PagedSplatsOptions {
@@ -345,26 +350,13 @@ export class PagedSplats implements SplatSource {
       const textureIndices = indicesTexture.image.data as Uint32Array;
       textureIndices.set(indices.subarray(0, numSplats));
 
-      const gl = renderer.getContext() as WebGL2RenderingContext;
-      renderer.state.activeTexture(gl.TEXTURE0);
-      renderer.state.bindTexture(
-        gl.TEXTURE_2D,
-        getGlTexture(renderer, indicesTexture),
-      );
-      gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
-      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-      gl.texSubImage2D(
-        gl.TEXTURE_2D,
-        0,
-        0,
-        0,
+      uploadU32DataTextureRows(
+        renderer,
+        indicesTexture,
         4096,
         rows,
-        gl.RGBA_INTEGER,
-        gl.UNSIGNED_INT,
-        indices,
+        textureIndices,
       );
-      renderer.state.bindTexture(gl.TEXTURE_2D, null);
     }
   }
 
@@ -1301,23 +1293,6 @@ function uploadTextureLayer(
   texture.value.addLayerUpdate(layer);
   texture.value.needsUpdate = true;
   texture.value.source.dataReady = true;
-}
-
-function getGlTexture(
-  renderer: THREE.WebGLRenderer,
-  texture: THREE.Texture,
-): WebGLTexture {
-  if (!renderer.properties.has(texture)) {
-    throw new Error("texture not found");
-  }
-  const props = renderer.properties.get(texture) as {
-    __webglTexture: WebGLTexture;
-  };
-  const glTexture = props.__webglTexture;
-  if (!glTexture) {
-    throw new Error("texture not found");
-  }
-  return glTexture;
 }
 
 async function fetchRange({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1676,3 +1676,44 @@ export class GunzipReader {
     return result;
   }
 }
+
+export function uploadU32DataTextureRows(
+  renderer: THREE.WebGLRenderer,
+  texture: THREE.Texture,
+  width: number,
+  rows: number,
+  data: Uint32Array,
+) {
+  const gl = renderer.getContext() as WebGL2RenderingContext;
+
+  const props = renderer.properties.get(texture) as {
+    __webglTexture: WebGLTexture;
+  };
+  const glTexture = props?.__webglTexture;
+  if (!glTexture) {
+    throw new Error("texture not found");
+  }
+  // Note: instead of saving and restoring the pixelStorei parameters
+  //       renderer.state.pixelStorei can be used with Three.js >= r184
+  const currentFlipY = gl.getParameter(gl.UNPACK_FLIP_Y_WEBGL);
+  const currentPremultiply = gl.getParameter(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL);
+  renderer.state.activeTexture(gl.TEXTURE0);
+  renderer.state.bindTexture(gl.TEXTURE_2D, glTexture);
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+  gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+  gl.texSubImage2D(
+    gl.TEXTURE_2D,
+    0,
+    0,
+    0,
+    width,
+    rows,
+    gl.RGBA_INTEGER,
+    gl.UNSIGNED_INT,
+    data,
+  );
+  renderer.state.unbindTexture();
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, currentFlipY);
+  gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, currentPremultiply);
+}


### PR DESCRIPTION
Both `SplatPager` and `SparkRenderer` manually uploaded texture data using the `WebGLRenderingContext` directly. This stems from a limitation in Three.js preventing 2D regions from easily being updated, see https://github.com/mrdoob/three.js/issues/32254. This PR extracts the logic into a utility function to avoid duplication.

Additionally the `pixelStorei` parameters set as part of this procedure weren't restored to the values they were before the upload. This becomes a problem with Three.js >= r184 as it now caches the parameter values in its `WebGLState`, see #366. This PR ensures they are now properly restored. Once Spark requires Three.js 184 or later it can switch to `renderer.state.pixelStorei` instead.

Fixes #366 
