### PR TITLE
Add build:wasm step to build-dist.yml workflow

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build spark-rs
+        run: npm run build:wasm
+
       - name: Build Dist
         run: npm run build
 


### PR DESCRIPTION
The `build-dist` workflow depended on either `npm install` or `npm run build` to also build the Rust project. This behaviour has changed back-and-forth with 2.0.0 removing the automatic step (`prepare`), #304 re-introducing it and #354 removing it again.

The current state is that you have to run the following three commands as listed in the README.md:
```bash
npm install
npm run build:wasm
npm run build
```

This PR adds the missing `npm run build:wasm` step to the `build-dist.yml` workflow. This _should_ fix the workflow, though I haven't tested/verified this as I can't manually trigger it. @dmarcos 