### PR TITLE
Clamp splat RGB to positive in splatVertex, matching the reference rasterizer

### DIFF
--- a/src/shaders/splatDefines.glsl
+++ b/src/shaders/splatDefines.glsl
@@ -309,7 +309,6 @@ void packSplatExtCov(
     out uvec4 packedData, out uvec4 packedData2,
     vec3 center, vec4 rgba, vec3 xxyyzz, vec3 xyxzyz
 ) {
-    rgba = mix(clamp(rgba, 0.0, 65504.0), vec4(0.0), isnan(rgba));
     packedData.x = floatBitsToUint(center.x);
     packedData.y = floatBitsToUint(center.y);
     packedData.z = floatBitsToUint(center.z);
@@ -358,7 +357,6 @@ void packSplatExt(
     out uvec4 packedData, out uvec4 packedData2,
     vec3 center, vec3 scales, vec4 quaternion, vec4 rgba
 ) {
-    rgba = mix(clamp(rgba, 0.0, 65504.0), vec4(0.0), isnan(rgba));
     packedData.x = floatBitsToUint(center.x);
     packedData.y = floatBitsToUint(center.y);
     packedData.z = floatBitsToUint(center.z);

--- a/src/shaders/splatDefines.glsl
+++ b/src/shaders/splatDefines.glsl
@@ -309,6 +309,7 @@ void packSplatExtCov(
     out uvec4 packedData, out uvec4 packedData2,
     vec3 center, vec4 rgba, vec3 xxyyzz, vec3 xyxzyz
 ) {
+    rgba = mix(clamp(rgba, 0.0, 65504.0), vec4(0.0), isnan(rgba));
     packedData.x = floatBitsToUint(center.x);
     packedData.y = floatBitsToUint(center.y);
     packedData.z = floatBitsToUint(center.z);
@@ -357,6 +358,7 @@ void packSplatExt(
     out uvec4 packedData, out uvec4 packedData2,
     vec3 center, vec3 scales, vec4 quaternion, vec4 rgba
 ) {
+    rgba = mix(clamp(rgba, 0.0, 65504.0), vec4(0.0), isnan(rgba));
     packedData.x = floatBitsToUint(center.x);
     packedData.y = floatBitsToUint(center.y);
     packedData.z = floatBitsToUint(center.z);

--- a/src/shaders/splatVertex.glsl
+++ b/src/shaders/splatVertex.glsl
@@ -103,6 +103,10 @@ void main() {
         }
     }
 
+    // Match the reference 3DGS rasterizer (graphdeco-inria/diff-gaussian-rasterization),
+    // which clamps the SH-evaluated color to positive
+    rgba.rgb = max(rgba.rgb, vec3(0.0));
+
     adjustedStdDev = maxStdDev;
     if (rgba.a > 1.0) {
         // Stretch 1..2 to 1..5


### PR DESCRIPTION
Fixes #386

Trained 3DGS scenes normally contain some negative base colors. The packed encoders clamp those away at pack time, but `packSplatExt`/`packSplatExtCov` pack raw fp16 — the negatives then turn into NaN in `srgbToLinear` (`pow` with a negative base is undefined in GLSL) and, when rendering into a float target where blending doesn't clamp, end up in the framebuffer as black blobs and neon speckles. Screenshots and the full story in #386.

This adds the same clamp semantics the packed path already has, at the top of both ext pack functions: negatives and NaN go to zero (a NaN alpha then falls below `minAlpha` and the splat is discarded), +Inf caps at fp16 max, and everything in between passes through so the ext encoding keeps its HDR headroom.

Output on a normal canvas is byte-identical before/after — the fixed-function blend clamp was already enforcing these semantics there — so the change only shows up where things were broken.
