### PR TITLE
Handle preUpdate ahead of updating material uniforms to avoid 1 frame latency

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -734,6 +734,32 @@ export class SparkRenderer extends THREE.Mesh {
     const isNewFrame = frame !== spark.lastFrame;
     spark.lastFrame = frame;
 
+    // Trigger update (either sync in case of preUpdate, or async through setTimeout)
+    if (spark.autoUpdate && isNewFrame) {
+      const preUpdate = spark.preUpdate && !renderer.xr.isPresenting;
+      const useCamera = renderer.xr.isPresenting
+        ? renderer.xr.getCamera()
+        : camera;
+      if (preUpdate) {
+        spark.updateInternal({
+          scene,
+          camera: useCamera,
+          autoUpdate: true,
+        });
+      } else {
+        if (spark.updateTimeoutId === -1) {
+          spark.updateTimeoutId = setTimeout(() => {
+            spark.updateTimeoutId = -1;
+            spark.updateInternal({
+              scene,
+              camera: useCamera,
+              autoUpdate: true,
+            });
+          }, 1);
+        }
+      }
+    }
+
     // Determine render target
     const currentRenderTarget = renderer.getRenderTarget();
     const isXRRenderTarget = checkIsXRRenderTarget(currentRenderTarget);
@@ -827,31 +853,6 @@ export class SparkRenderer extends THREE.Mesh {
     this.uniforms.deltaTime.value = spark.display.deltaTime;
     // Alternating debug flag that can aid in visual debugging
     this.uniforms.debugFlag.value = (performance.now() / 1000.0) % 2.0 < 1.0;
-
-    if (spark.autoUpdate && isNewFrame) {
-      const preUpdate = spark.preUpdate && !renderer.xr.isPresenting;
-      const useCamera = renderer.xr.isPresenting
-        ? renderer.xr.getCamera()
-        : camera;
-      if (preUpdate) {
-        spark.updateInternal({
-          scene,
-          camera: useCamera,
-          autoUpdate: true,
-        });
-      } else {
-        if (spark.updateTimeoutId === -1) {
-          spark.updateTimeoutId = setTimeout(() => {
-            spark.updateTimeoutId = -1;
-            spark.updateInternal({
-              scene,
-              camera: useCamera,
-              autoUpdate: true,
-            });
-          }, 1);
-        }
-      }
-    }
 
     spark.dirty = false;
   }


### PR DESCRIPTION
Fixes #390 

The `preUpdate` flag is supposed to ensure the splat update takes place _before_ rendering. While this was technically true, the updated splats were not used in the rendering as the relevant uniforms had already been set. This also meant that the uniforms referred to values from an accumulator that had already been released.

This PR moves the `updateInternal` call to the start of the `onBeforeRendering` method. In case of `preUpdate` this would ensure a synchronous update before the uniforms were updated. Whereas the default case is still to schedule the update asynchronously through `setTimeout`.

Note that whether or not the result of update is visible that same frame still depends on whether or not the mappings are compatible, though in simple cases like `recolor` this holds.