### PR TITLE
Fix RangeError when all SH arrays are present

### DIFF
--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -1170,7 +1170,10 @@ export class SplatPager {
           data.extra.sh3a as Uint32Array,
           data.extra.sh3b as Uint32Array,
         ];
-        shArrays.length = shArrays.findIndex((sh) => !sh);
+        // findIndex returns -1 when all SH arrays are present — keep the full list
+        // (Array.length = -1 throws a RangeError)
+        const firstMissingSh = shArrays.findIndex((sh) => !sh);
+        if (firstMissingSh >= 0) shArrays.length = firstMissingSh;
         this.newUploads.push({
           page,
           numSplats,
@@ -1185,7 +1188,10 @@ export class SplatPager {
           data.extra.sh2 as Uint32Array,
           data.extra.sh3 as Uint32Array,
         ];
-        shArrays.length = shArrays.findIndex((sh) => !sh);
+        // findIndex returns -1 when all SH arrays are present — keep the full list
+        // (Array.length = -1 throws a RangeError)
+        const firstMissingSh = shArrays.findIndex((sh) => !sh);
+        if (firstMissingSh >= 0) shArrays.length = firstMissingSh;
         this.newUploads.push({
           page,
           numSplats,


### PR DESCRIPTION
`SplatPager` truncates the SH upload list with

```js
shArrays.length = shArrays.findIndex((sh) => !sh);
```

`findIndex` returns `-1` when no entry is missing — i.e. whenever a chunk has **all** SH bands (the normal case at `maxSh: 3`) — and setting `Array.length = -1` throws `RangeError: Invalid array length`. On current `main` this breaks paged loading of any file with full SH data (not present in the released 2.1.0).

Fix: only truncate when a missing entry exists (both sites).

Repro: load a paged `.rad` with SH bands at default `maxSh` — the first chunk upload throws.