### PR TITLE
Use uploadU32DataTextureRows for LoD index uploads

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -1627,31 +1627,14 @@ export class SparkRenderer extends THREE.Mesh {
           // instance.indices.set(indices.subarray(0, numSplats));
 
           const renderer = this.renderer;
-          const gl = renderer.getContext() as WebGL2RenderingContext;
           if (renderer.properties.has(instance.texture)) {
-            const props = renderer.properties.get(instance.texture) as {
-              __webglTexture: WebGLTexture;
-            };
-            const glTexture = props.__webglTexture;
-            if (!glTexture) {
-              throw new Error("lodIndices texture not found");
-            }
-            renderer.state.activeTexture(gl.TEXTURE0);
-            renderer.state.bindTexture(gl.TEXTURE_2D, glTexture);
-            gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
-            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-            gl.texSubImage2D(
-              gl.TEXTURE_2D,
-              0,
-              0,
-              0,
+            uploadU32DataTextureRows(
+              renderer,
+              instance.texture,
               4096,
               rows,
-              gl.RGBA_INTEGER,
-              gl.UNSIGNED_INT,
               indices,
             );
-            renderer.state.bindTexture(gl.TEXTURE_2D, null);
           }
         }
       }


### PR DESCRIPTION
Fixes #405.

`updateLodIndices` duplicates the `texSubImage2D` path inline instead of calling
`uploadU32DataTextureRows`, which is already imported in this file and used a few hundred
lines above for the ordering texture. The inline copy is missing the save/restore of the
`pixelStorei` parameters that the helper performs.

Leaving `UNPACK_FLIP_Y_WEBGL` at `false` desynchronises three.js's `WebGLState` cache.
The cache still believes the value is `true`, so three skips the `pixelStorei` call before
its own uploads, and every subsequent texture is transferred with the wrong unpack state —
unrelated textures (text atlases, UI images) render vertically flipped.

Replacing the block with the helper also picks up the `UNPACK_PREMULTIPLY_ALPHA_WEBGL`
save/restore and `renderer.state.unbindTexture()`, and drops ~20 lines.

Behaviour is otherwise identical: same target texture, same 4096 x rows region, same
`RGBA_INTEGER` / `UNSIGNED_INT` upload. The `renderer.properties.has(...)` guard is kept, so
the "texture not found" throw inside the helper stays unreachable here as before.

Repro for the underlying issue (plain three.js, no build step):
https://sawa-zen.github.io/three-texture-flip-repro/?pollute=1

`npx biome check` and `npm test` pass. `npx tsc --noEmit` reports only the pre-existing
`spark-rs` module errors from not having run `build:wasm`; nothing in `SparkRenderer.ts`.

Note: the comment in `uploadU32DataTextureRows` mentions `renderer.state.pixelStorei` as an
alternative for three.js >= r184. Happy to switch to that instead if you prefer, but I kept this
patch to "call the existing helper" so it stays minimal.