### PR TITLE
Add reflected SH support for MirrorGaussian scenes

### DIFF
--- a/examples/mirrorgaussian/README.md
+++ b/examples/mirrorgaussian/README.md
@@ -1,0 +1,43 @@
+# MirrorGaussian
+
+This example composites a real-scene splat pass with one reflected splat and
+mask pass per mirror. It expects SPZ files beside a `mirrorgaussian-spark-v2`
+manifest:
+
+```text
+assets/
+  mirror.json
+  real.spz
+  mirrors/
+    <mirror-id>/
+      mask.spz
+      mirror.spz
+```
+
+The manifest's asset paths may use `.ply`; the example substitutes `.spz` when
+loading them. Each mirror entry must provide `sh_view_basis_row_major`, a 3x3
+object-space basis used to evaluate the reflected scene's spherical harmonics.
+
+```json
+{
+  "schema": "mirrorgaussian-spark-v2",
+  "assets": { "real": "real.ply" },
+  "mirrors": [
+    {
+      "id": "1",
+      "assets": {
+        "mask": "mirrors/1/mask.ply",
+        "mirror": "mirrors/1/mirror.ply"
+      },
+      "sh_view_basis_row_major": [-1, 0, 0, 0, 1, 0, 0, 0, 1]
+    }
+  ]
+}
+```
+
+The passes use one camera snapshot and finish sorting before their render
+targets are composited. LOD is disabled because independently updated LOD trees
+can make the real, reflected, and mask passes use different camera states.
+
+Run `npm start`, then open
+`http://localhost:8080/examples/mirrorgaussian/`.

--- a/examples/mirrorgaussian/index.html
+++ b/examples/mirrorgaussian/index.html
@@ -1,0 +1,520 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MirrorGaussian Spark diagnostic</title>
+  <style>
+    html, body { margin: 0; height: 100%; overflow: hidden; background: #080a0d; color: #f3f4f6; font: 13px/1.4 system-ui, sans-serif; }
+    canvas { display: block; }
+    #panel { position: fixed; z-index: 2; top: 14px; left: 14px; width: 290px; padding: 12px 14px; border: 1px solid #ffffff20; border-radius: 10px; background: #11151bcc; backdrop-filter: blur(12px); }
+    #status { margin-top: 6px; color: #b9c1cc; white-space: pre-line; }
+    #modes { display: flex; gap: 6px; margin-top: 10px; }
+    button { border: 1px solid #ffffff24; border-radius: 6px; padding: 5px 9px; color: inherit; background: #ffffff0d; cursor: pointer; }
+    button.active { background: #dbeafe; color: #172033; }
+  </style>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "../js/vendor/three/build/three.module.js",
+        "three/addons/": "../js/vendor/three/examples/jsm/",
+        "@sparkjsdev/spark": "../../dist/spark.module.js"
+      }
+    }
+  </script>
+</head>
+<body>
+  <div id="panel">
+    <strong>MirrorGaussian / Spark</strong>
+    <div id="scene-info">Loading scene...</div>
+    <div id="status">Loading manifest...</div>
+    <div id="modes">
+      <button data-mode="final" class="active">Final</button>
+      <button data-mode="real">Real</button>
+      <button data-mode="mirror">Mirror</button>
+      <button data-mode="mask">Mask</button>
+    </div>
+  </div>
+
+  <script type="module">
+    import * as THREE from "three";
+    import { SparkRenderer, SplatMesh } from "@sparkjsdev/spark";
+
+    const status = document.querySelector("#status");
+    const manifest = await fetch("./assets/mirror.json").then((response) => response.json());
+    const assetUrl = (path) => `./assets/${path.replace(/\.ply$/, ".spz")}`;
+    const useLod = false;
+    let mode = "final";
+    document.querySelector("#scene-info").textContent =
+      `SPZ diagnostic, ${manifest.mirrors.length} mirrors`;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: false });
+    renderer.setPixelRatio(Math.min(devicePixelRatio, 1.5));
+    renderer.setSize(innerWidth, innerHeight);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    document.body.appendChild(renderer.domElement);
+
+    const camera = new THREE.PerspectiveCamera(60, innerWidth / innerHeight, 0.01, 1000);
+    renderer.domElement.style.touchAction = "none";
+
+    const maskFragmentShader = `
+      precision highp float;
+      precision highp int;
+      #include <splatDefines>
+      uniform float near;
+      uniform float far;
+      uniform float maxStdDev;
+      uniform float minAlpha;
+      uniform float falloff;
+      out vec4 fragColor;
+      in vec4 vRgba;
+      in vec2 vSplatUv;
+      in vec3 vNdc;
+      flat in uint vSplatIndex;
+      flat in float adjustedStdDev;
+      #include <logdepthbuf_pars_fragment>
+      void main() {
+        vec4 rgba = vRgba;
+        float z2 = dot(vSplatUv, vSplatUv);
+        if (z2 > adjustedStdDev * adjustedStdDev) discard;
+        if (rgba.a <= 1.0) {
+          rgba.a = mix(rgba.a, rgba.a * exp(-0.5 * z2), falloff);
+        } else {
+          float a = exp((rgba.a * rgba.a - 1.0) / 2.718281828459045);
+          float alpha = 1.0 - pow(1.0 - exp(-0.5 * z2), a);
+          rgba.a = mix(1.0, alpha, falloff);
+        }
+        if (rgba.a < minAlpha) discard;
+        #ifdef PREMULTIPLIED_ALPHA
+          fragColor = vec4(rgba.rgb * rgba.a, rgba.a);
+        #else
+          fragColor = rgba;
+        #endif
+        #include <logdepthbuf_fragment>
+      }
+    `;
+
+    function makePass({ background, mask = false }) {
+      const scene = new THREE.Scene();
+      scene.background = new THREE.Color(background);
+      const spark = new SparkRenderer({
+        renderer,
+        target: {
+          width: innerWidth,
+          height: innerHeight,
+          colorSpace: mask ? THREE.NoColorSpace : THREE.SRGBColorSpace,
+        },
+        fragmentShader: mask ? maskFragmentShader : undefined,
+        lodSplatCount: mask ? 250000 : 500000,
+      });
+      scene.add(spark);
+      return { scene, spark };
+    }
+
+    const realPass = makePass({ background: 0x080a0d });
+    const mirrorPasses = manifest.mirrors.map(() => makePass({ background: 0x080a0d }));
+    const maskPasses = manifest.mirrors.map(() => makePass({ background: 0xffffff, mask: true }));
+
+    function progress(name) {
+      return (event) => {
+        const percent = event.total ? Math.round(100 * event.loaded / event.total) : 0;
+        status.textContent = `${name}: ${percent}%`;
+      };
+    }
+
+    const realMesh = new SplatMesh({
+      url: assetUrl(manifest.assets.real),
+      lod: useLod,
+      onProgress: progress("Real scene"),
+    });
+    realMesh.quaternion.set(1, 0, 0, 0);
+    realPass.scene.add(realMesh);
+    await realMesh.initialized;
+
+    const bounds = realMesh.getBoundingBox();
+    const center = bounds.getCenter(new THREE.Vector3()).applyQuaternion(realMesh.quaternion);
+    const size = bounds.getSize(new THREE.Vector3());
+    const radius = Math.max(size.x, size.y, size.z) * 0.5;
+    const moveSpeed = Math.max(radius * 0.6, 0.5);
+    camera.position.copy(center).add(new THREE.Vector3(0, radius * 0.2, radius * 1.8));
+    camera.lookAt(center);
+    camera.near = Math.max(radius / 1000, 0.001);
+    camera.far = Math.max(radius * 20, 100);
+    camera.updateProjectionMatrix();
+    status.textContent = "Real scene loaded\nLoading mirror assets...";
+
+    const pressedKeys = new Set();
+    const movementKeys = new Set(["KeyW", "KeyA", "KeyS", "KeyD"]);
+    addEventListener("keydown", (event) => {
+      pressedKeys.add(event.code);
+      if (movementKeys.has(event.code)) {
+        beginNavigation();
+      }
+    });
+    addEventListener("keyup", (event) => {
+      pressedKeys.delete(event.code);
+      if (![...movementKeys].some((key) => pressedKeys.has(key))) {
+        endNavigation();
+      }
+    });
+    addEventListener("blur", () => {
+      pressedKeys.clear();
+      endNavigation();
+    });
+
+    function updateMovement(deltaSeconds) {
+      const forwardAmount =
+        Number(pressedKeys.has("KeyW")) - Number(pressedKeys.has("KeyS"));
+      const rightAmount =
+        Number(pressedKeys.has("KeyD")) - Number(pressedKeys.has("KeyA"));
+      if (forwardAmount === 0 && rightAmount === 0) return false;
+
+      const forward = new THREE.Vector3();
+      camera.getWorldDirection(forward);
+      forward.y = 0;
+      if (forward.lengthSq() < 1e-6) forward.set(0, 0, -1);
+      forward.normalize();
+      const right = new THREE.Vector3().crossVectors(forward, camera.up).normalize();
+      const movement = forward.multiplyScalar(forwardAmount).addScaledVector(right, rightAmount);
+      if (movement.lengthSq() > 1) movement.normalize();
+      const boost =
+        pressedKeys.has("ShiftLeft") ||
+        pressedKeys.has("ShiftRight") ||
+        (pointerDragging && pointerButton === 2)
+          ? 3
+          : 1;
+      movement.multiplyScalar(moveSpeed * boost * deltaSeconds);
+      camera.position.add(movement);
+      return true;
+    }
+
+    const compositeUniforms = {
+      realTexture: { value: realPass.spark.target.texture },
+      mode: { value: 1 },
+    };
+    mirrorPasses.forEach((pass, index) => {
+      compositeUniforms[`mirrorTexture${index}`] = { value: pass.spark.target.texture };
+      compositeUniforms[`maskTexture${index}`] = { value: maskPasses[index].spark.target.texture };
+    });
+    const mirrorUniformDeclarations = manifest.mirrors.map((_, index) => `
+      uniform sampler2D mirrorTexture${index};
+      uniform sampler2D maskTexture${index};
+    `).join("");
+    const mirrorCompositeStatements = manifest.mirrors.map((_, index) => `
+      vec3 mirrorRgb${index} = texture2D(mirrorTexture${index}, vUv).rgb;
+      float mirrorWeight${index} = 1.0 - clamp(texture2D(maskTexture${index}, vUv).r, 0.0, 1.0);
+      rgb = mix(rgb, mirrorRgb${index}, mirrorWeight${index});
+      mirrorOnly += mirrorRgb${index} * mirrorWeight${index};
+      mirrorCoverage = max(mirrorCoverage, mirrorWeight${index});
+    `).join("");
+
+    const compositeScene = new THREE.Scene();
+    const compositeCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    const compositeMaterial = new THREE.ShaderMaterial({
+      uniforms: compositeUniforms,
+      vertexShader: `
+        varying vec2 vUv;
+        void main() {
+          vUv = uv;
+          gl_Position = vec4(position.xy, 0.0, 1.0);
+        }
+      `,
+      fragmentShader: `
+        uniform sampler2D realTexture;
+        ${mirrorUniformDeclarations}
+        uniform int mode;
+        varying vec2 vUv;
+        void main() {
+          vec3 realRgb = texture2D(realTexture, vUv).rgb;
+          vec3 rgb = realRgb;
+          vec3 mirrorOnly = vec3(0.0);
+          float mirrorCoverage = 0.0;
+          ${mirrorCompositeStatements}
+          if (mode == 1) rgb = realRgb;
+          if (mode == 2) rgb = mirrorOnly;
+          if (mode == 3) rgb = vec3(1.0 - mirrorCoverage);
+          gl_FragColor = vec4(rgb, 1.0);
+          #include <colorspace_fragment>
+        }
+      `,
+      depthTest: false,
+      depthWrite: false,
+    });
+    compositeScene.add(new THREE.Mesh(new THREE.PlaneGeometry(2, 2), compositeMaterial));
+
+    const reflectionPasses = [...mirrorPasses, ...maskPasses];
+    let realDirty = true;
+    let reflectionsDirty = true;
+    let reflectionsLoading = true;
+    let reflectionQueue = [];
+    let settleAt = performance.now() + 300;
+    let navigationActive = false;
+    let navigationEndTimer;
+    let nextRealRenderAt = 0;
+    let nextInteractiveRenderAt = 0;
+    let synchronizedRenderRunning = false;
+    let synchronizedRenderRequested = false;
+    const realWarmupUntil = performance.now() + 2000;
+
+    function requestNavigationRender() {
+      realDirty = true;
+      reflectionsDirty = true;
+      reflectionQueue = [];
+      settleAt = performance.now() + 300;
+    }
+
+    async function renderSynchronizedNavigationFrame() {
+      synchronizedRenderRequested = true;
+      if (synchronizedRenderRunning) return;
+      synchronizedRenderRunning = true;
+
+      try {
+        while (synchronizedRenderRequested) {
+          synchronizedRenderRequested = false;
+          const cameraSnapshot = camera.clone();
+          const passes = [realPass, ...reflectionPasses];
+
+          // Each Spark renderer sorts asynchronously. Wait for every pass before
+          // publishing any target so the composite uses one camera pose.
+          for (const pass of passes) {
+            await pass.spark.update({
+              scene: pass.scene,
+              camera: cameraSnapshot,
+            });
+          }
+          for (const pass of passes) {
+            pass.spark.renderTarget({
+              scene: pass.scene,
+              camera: cameraSnapshot,
+            });
+          }
+          renderer.setRenderTarget(null);
+          renderer.render(compositeScene, compositeCamera);
+        }
+      } finally {
+        synchronizedRenderRunning = false;
+      }
+    }
+
+    function beginNavigation() {
+      clearTimeout(navigationEndTimer);
+      navigationActive = true;
+      requestNavigationRender();
+    }
+
+    function endNavigation() {
+      clearTimeout(navigationEndTimer);
+      navigationEndTimer = setTimeout(() => {
+        navigationActive = false;
+        requestNavigationRender();
+      }, 250);
+    }
+
+    const lookEuler = new THREE.Euler().setFromQuaternion(
+      camera.quaternion,
+      "YXZ",
+    );
+    let pointerDragging = false;
+    let pointerButton = 0;
+    let pointerX = 0;
+    let pointerY = 0;
+
+    renderer.domElement.addEventListener("pointerdown", (event) => {
+      if (event.button !== 0 && event.button !== 2) return;
+      event.preventDefault();
+      pointerDragging = true;
+      pointerButton = event.button;
+      pointerX = event.clientX;
+      pointerY = event.clientY;
+      renderer.domElement.setPointerCapture(event.pointerId);
+      beginNavigation();
+    });
+
+    renderer.domElement.addEventListener("pointermove", (event) => {
+      if (!pointerDragging) return;
+      const deltaX = event.clientX - pointerX;
+      const deltaY = event.clientY - pointerY;
+      if (pointerButton === 0) {
+        lookEuler.y -= deltaX * 0.003;
+        lookEuler.x -= deltaY * 0.003;
+        lookEuler.x = THREE.MathUtils.clamp(
+          lookEuler.x,
+          -Math.PI / 2 + 0.01,
+          Math.PI / 2 - 0.01,
+        );
+        camera.quaternion.setFromEuler(lookEuler);
+      } else {
+        const forward = new THREE.Vector3();
+        const right = new THREE.Vector3();
+        const up = new THREE.Vector3();
+        camera.getWorldDirection(forward);
+        right.crossVectors(forward, camera.up).normalize();
+        up.crossVectors(right, forward).normalize();
+        camera.position
+          .addScaledVector(right, deltaX * moveSpeed * 0.01)
+          .addScaledVector(up, -deltaY * moveSpeed * 0.01);
+      }
+      pointerX = event.clientX;
+      pointerY = event.clientY;
+      requestNavigationRender();
+    });
+
+    function stopPointerDrag(event) {
+      if (!pointerDragging) return;
+      event.preventDefault();
+      pointerDragging = false;
+      if (renderer.domElement.hasPointerCapture(event.pointerId)) {
+        renderer.domElement.releasePointerCapture(event.pointerId);
+      }
+      endNavigation();
+    }
+
+    renderer.domElement.addEventListener("pointerup", stopPointerDrag);
+    renderer.domElement.addEventListener("pointercancel", stopPointerDrag);
+    renderer.domElement.addEventListener("contextmenu", (event) => {
+      event.preventDefault();
+    });
+    renderer.domElement.addEventListener("click", (event) => {
+      event.preventDefault();
+    });
+    renderer.domElement.addEventListener("auxclick", (event) => {
+      event.preventDefault();
+    });
+    renderer.domElement.addEventListener(
+      "wheel",
+      (event) => {
+        event.preventDefault();
+        const forward = new THREE.Vector3();
+        camera.getWorldDirection(forward);
+        const wheelDelta = THREE.MathUtils.clamp(event.deltaY, -100, 100);
+        camera.position.addScaledVector(
+          forward,
+          -wheelDelta * moveSpeed * 0.002,
+        );
+        beginNavigation();
+        endNavigation();
+      },
+      { passive: false },
+    );
+
+    document.querySelectorAll("button[data-mode]").forEach((button) => {
+      button.addEventListener("click", () => {
+        mode = button.dataset.mode;
+        compositeMaterial.uniforms.mode.value =
+          reflectionsLoading && mode === "final"
+            ? 1
+            : ["final", "real", "mirror", "mask"].indexOf(mode);
+        document.querySelectorAll("button[data-mode]").forEach((item) => item.classList.toggle("active", item === button));
+      });
+    });
+
+    addEventListener("resize", () => {
+      camera.aspect = innerWidth / innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(innerWidth, innerHeight);
+      for (const pass of [realPass, ...mirrorPasses, ...maskPasses]) {
+        pass.spark.target.setSize(innerWidth, innerHeight);
+      }
+    });
+
+    let lastFrameTime = performance.now();
+    renderer.setAnimationLoop((time) => {
+      const deltaSeconds = Math.min((time - lastFrameTime) / 1000, 0.1);
+      lastFrameTime = time;
+      if (updateMovement(deltaSeconds)) {
+        requestNavigationRender();
+      }
+
+      const now = performance.now();
+      if (navigationActive && now >= nextInteractiveRenderAt) {
+        renderSynchronizedNavigationFrame();
+        realDirty = false;
+        nextInteractiveRenderAt = now + 120;
+      } else if (
+        !synchronizedRenderRunning &&
+        (realDirty || now < realWarmupUntil) &&
+        now >= nextRealRenderAt
+      ) {
+        realPass.spark.renderTarget({ scene: realPass.scene, camera });
+        realDirty = false;
+        nextRealRenderAt = now + (navigationActive ? 75 : 150);
+      }
+
+      if (
+        !navigationActive &&
+        !synchronizedRenderRunning &&
+        reflectionsDirty &&
+        reflectionQueue.length === 0 &&
+        now >= settleAt
+      ) {
+        // Three rounds allow Spark's asynchronous sort to become visible
+        // without blocking input on all thirteen passes in one frame.
+        reflectionQueue = [
+          ...reflectionPasses,
+          ...reflectionPasses,
+          ...reflectionPasses,
+        ];
+        reflectionsDirty = false;
+      }
+
+      const reflectionPass = reflectionQueue.shift();
+      if (reflectionPass) {
+        reflectionPass.spark.renderTarget({
+          scene: reflectionPass.scene,
+          camera,
+        });
+        if (reflectionQueue.length === 0) {
+          compositeMaterial.uniforms.mode.value =
+            ["final", "real", "mirror", "mask"].indexOf(mode);
+        }
+      }
+
+      renderer.setRenderTarget(null);
+      renderer.render(compositeScene, compositeCamera);
+    });
+
+    async function loadReflections() {
+      for (let index = 0; index < manifest.mirrors.length; index++) {
+        const mirrorSpec = manifest.mirrors[index];
+        const mirrorNumber = index + 1;
+        status.textContent =
+          `Real scene ready\nLoading mirror ${mirrorNumber}/${manifest.mirrors.length} reflection...`;
+        const mirrorMesh = new SplatMesh({
+          url: assetUrl(mirrorSpec.assets.mirror),
+          lod: useLod,
+          shViewBasis: new THREE.Matrix3().set(
+            ...mirrorSpec.sh_view_basis_row_major,
+          ),
+          onProgress: progress(`Mirror ${mirrorSpec.id} reflection`),
+        });
+        mirrorMesh.quaternion.set(1, 0, 0, 0);
+        mirrorPasses[index].scene.add(mirrorMesh);
+        await mirrorMesh.initialized;
+
+        status.textContent =
+          `Real scene ready\nLoading mirror ${mirrorNumber}/${manifest.mirrors.length} mask...`;
+        const maskMesh = new SplatMesh({
+          url: assetUrl(mirrorSpec.assets.mask),
+          lod: useLod,
+          onProgress: progress(`Mirror ${mirrorSpec.id} mask`),
+        });
+        maskMesh.maxSh = 0;
+        maskMesh.quaternion.set(1, 0, 0, 0);
+        maskPasses[index].scene.add(maskMesh);
+        await maskMesh.initialized;
+      }
+
+      reflectionsLoading = false;
+      requestNavigationRender();
+      status.textContent =
+        `Loaded ${manifest.mirrors.length} mirrors\nLeft-drag look; right-drag pan; wheel or WASD move`;
+    }
+
+    loadReflections().catch((error) => {
+      reflectionsLoading = false;
+      status.textContent = `Mirror loading failed\n${error.message}`;
+      console.error(error);
+    });
+  </script>
+</body>
+</html>

--- a/src/ExtSplats.ts
+++ b/src/ExtSplats.ts
@@ -16,6 +16,7 @@ import {
   add,
   combineGsplat,
   defineExtSplats,
+  mul,
   normalize,
   readExtSplat,
   splatTexCoord,
@@ -270,14 +271,21 @@ export class ExtSplats implements SplatSource {
   fetchSplat({
     index,
     viewOrigin,
-  }: { index: DynoVal<"int">; viewOrigin?: DynoVal<"vec3"> }): DynoVal<
-    typeof Gsplat
-  > {
+    viewBasis,
+  }: {
+    index: DynoVal<"int">;
+    viewOrigin?: DynoVal<"vec3">;
+    viewBasis?: DynoVal<"mat3">;
+  }): DynoVal<typeof Gsplat> {
     let gsplat = readExtSplat(this.dyno, index);
 
     if (this.hasRgbDir() && viewOrigin) {
       const splatCenter = splitGsplat(gsplat).outputs.center;
-      const viewDir = normalize(sub(splatCenter, viewOrigin));
+      let viewDir = sub(splatCenter, viewOrigin);
+      if (viewBasis) {
+        viewDir = mul(viewBasis, viewDir);
+      }
+      viewDir = normalize(viewDir);
       const { sh1Texture, sh2Texture, sh3TextureA, sh3TextureB } =
         this.ensureShTextures();
       let { rgb } = evaluateExtSH({

--- a/src/PackedSplats.ts
+++ b/src/PackedSplats.ts
@@ -28,6 +28,7 @@ import {
   DynoVec4,
   add,
   dynoBlock,
+  mul,
   normalize,
   outputPackedSplat,
   sub,
@@ -326,14 +327,21 @@ export class PackedSplats implements SplatSource {
   fetchSplat({
     index,
     viewOrigin,
-  }: { index: DynoVal<"int">; viewOrigin?: DynoVal<"vec3"> }): DynoVal<
-    typeof Gsplat
-  > {
+    viewBasis,
+  }: {
+    index: DynoVal<"int">;
+    viewOrigin?: DynoVal<"vec3">;
+    viewBasis?: DynoVal<"mat3">;
+  }): DynoVal<typeof Gsplat> {
     let gsplat = readPackedSplat(this.dyno, index);
 
     if (this.hasRgbDir() && viewOrigin) {
       const splatCenter = splitGsplat(gsplat).outputs.center;
-      const viewDir = normalize(sub(splatCenter, viewOrigin));
+      let viewDir = sub(splatCenter, viewOrigin);
+      if (viewBasis) {
+        viewDir = mul(viewBasis, viewDir);
+      }
+      viewDir = normalize(viewDir);
       const { sh1Texture, sh2Texture, sh3Texture } = this.ensureShTextures();
       let { rgb } = evaluatePackedSH({
         coord: splatTexCoord(index),

--- a/src/SplatMesh.ts
+++ b/src/SplatMesh.ts
@@ -33,6 +33,7 @@ import {
   DynoBool,
   DynoFloat,
   DynoInt,
+  DynoMat3,
   DynoUsampler2D,
   type DynoVal,
   DynoVec4,
@@ -89,6 +90,9 @@ export type SplatMeshOptions = {
   editable?: boolean;
   // Controls whether SplatMesh participates in Three.js raycasting (default: true)
   raycastable?: boolean;
+  // Object-space basis applied to SH view directions before evaluation.
+  // (default: identity)
+  shViewBasis?: THREE.Matrix3;
   // Minimum opacity for raycasting splats. (default: 0.2)
   minRaycastOpacity?: number;
   // Callback function that is called every frame to update the mesh.
@@ -157,6 +161,7 @@ export type SplatMeshContext = {
   covViewToWorld: CovSplatTransformer;
   covWorldToView: CovSplatTransformer;
   covViewToObject: CovSplatTransformer;
+  shViewBasis: DynoMat3<"shViewBasis", THREE.Matrix3>;
   recolor: DynoVec4<THREE.Vector4>;
   time: DynoFloat;
   deltaTime: DynoFloat;
@@ -178,9 +183,12 @@ export interface SplatSource {
   fetchSplat({
     index,
     viewOrigin,
-  }: { index: DynoVal<"int">; viewOrigin?: DynoVal<"vec3"> }): DynoVal<
-    typeof Gsplat
-  >;
+    viewBasis,
+  }: {
+    index: DynoVal<"int">;
+    viewOrigin?: DynoVal<"vec3">;
+    viewBasis?: DynoVal<"mat3">;
+  }): DynoVal<typeof Gsplat>;
 
   forEachSplat(
     callback: (
@@ -252,6 +260,8 @@ export class SplatMesh extends SplatGenerator {
   recolor: THREE.Color = new THREE.Color(1, 1, 1);
   // Global opacity multiplier for all splats in the mesh. (default: 1)
   opacity = 1;
+  // Object-space basis applied to SH view directions.
+  readonly shViewBasis: THREE.Matrix3;
 
   // A SplatMeshContext consisting of useful scene and object dyno uniforms that can
   // be used to in the Gsplat processing pipeline, for example via objectModifier and
@@ -365,6 +375,10 @@ export class SplatMesh extends SplatGenerator {
       covViewToWorld: new CovSplatTransformer(),
       covWorldToView: new CovSplatTransformer(),
       covViewToObject: new CovSplatTransformer(),
+      shViewBasis: new DynoMat3({
+        key: "shViewBasis",
+        value: options.shViewBasis?.clone() ?? new THREE.Matrix3(),
+      }),
       recolor: new DynoVec4({
         value: new THREE.Vector4().setScalar(Number.NEGATIVE_INFINITY),
       }),
@@ -378,6 +392,7 @@ export class SplatMesh extends SplatGenerator {
         key: "lodIndices",
       }),
     };
+    this.shViewBasis = this.context.shViewBasis.value;
 
     this.covSplats = options.covSplats ?? false;
     if (this.covSplats && !this.extSplats) {
@@ -673,6 +688,7 @@ export class SplatMesh extends SplatGenerator {
         let gsplat = context.splats.fetchSplat({
           index,
           viewOrigin: viewToObject.translate,
+          viewBasis: context.shViewBasis,
         });
 
         if (this.splatRgba) {
@@ -748,6 +764,7 @@ export class SplatMesh extends SplatGenerator {
         let gsplat = context.splats.fetchSplat({
           index,
           viewOrigin: covViewToObject.offset,
+          viewBasis: context.shViewBasis,
         });
 
         if (this.splatRgba) {

--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -380,9 +380,11 @@ export class PagedSplats implements SplatSource {
   fetchSplat({
     index,
     viewOrigin,
+    viewBasis,
   }: {
     index: dyno.DynoVal<"int">;
     viewOrigin?: dyno.DynoVal<"vec3">;
+    viewBasis?: dyno.DynoVal<"mat3">;
   }): dyno.DynoVal<typeof dyno.Gsplat> {
     if (!this.pager) {
       throw new Error("PagedSplats.pager not set");
@@ -406,6 +408,7 @@ export class PagedSplats implements SplatSource {
           rgbMinMaxLnScaleMinMax: this.rgbMinMaxLnScaleMinMax,
           lodOpacity: this.lodOpacity,
           viewOrigin,
+          viewBasis: viewBasis ?? this.pager.identityViewBasis,
           numSh: this.dynoNumSh,
           shMax: this.shMax,
         }).gsplat;
@@ -422,6 +425,7 @@ export class PagedSplats implements SplatSource {
       return this.pager.readSplatExtDir.apply({
         index: splatIndex,
         viewOrigin,
+        viewBasis: viewBasis ?? this.pager.identityViewBasis,
         numSh: this.dynoNumSh,
       }).gsplat;
     }
@@ -566,6 +570,7 @@ export class SplatPager {
     dyno.DynoUsampler2DArray<"sh3", THREE.DataArrayTexture>,
     dyno.DynoUsampler2DArray<"sh3b", THREE.DataArrayTexture>,
   ];
+  readonly identityViewBasis: dyno.DynoMat3<"identityViewBasis", THREE.Matrix3>;
 
   readIndex: dyno.DynoBlock<
     { index: "int"; numSplats: "int"; indices: "usampler2D" },
@@ -585,13 +590,14 @@ export class SplatPager {
       rgbMinMaxLnScaleMinMax: "vec4";
       lodOpacity: "bool";
       viewOrigin: "vec3";
+      viewBasis: "mat3";
       numSh: "int";
       shMax: "vec3";
     },
     { gsplat: typeof dyno.Gsplat }
   >;
   readSplatExtDir: dyno.DynoBlock<
-    { index: "int"; viewOrigin: "vec3"; numSh: "int" },
+    { index: "int"; viewOrigin: "vec3"; viewBasis: "mat3"; numSh: "int" },
     { gsplat: typeof dyno.Gsplat }
   >;
 
@@ -641,6 +647,10 @@ export class SplatPager {
           value: texture,
         }),
     ) as typeof this.shTextures;
+    this.identityViewBasis = new dyno.DynoMat3({
+      key: "identityViewBasis",
+      value: new THREE.Matrix3(),
+    });
 
     this.readIndex = dyno.dynoBlock(
       { index: "int", numSplats: "int", indices: "usampler2D" },
@@ -718,6 +728,7 @@ export class SplatPager {
         rgbMinMaxLnScaleMinMax: "vec4",
         lodOpacity: "bool",
         viewOrigin: "vec3",
+        viewBasis: "mat3",
         numSh: "int",
         shMax: "vec3",
       },
@@ -727,6 +738,7 @@ export class SplatPager {
         rgbMinMaxLnScaleMinMax,
         lodOpacity,
         viewOrigin,
+        viewBasis,
         numSh,
         shMax,
       }) => {
@@ -735,10 +747,11 @@ export class SplatPager {
           !rgbMinMaxLnScaleMinMax ||
           !lodOpacity ||
           !viewOrigin ||
+          !viewBasis ||
           !numSh ||
           !shMax
         ) {
-          throw new Error("index and viewOrigin are required");
+          throw new Error("index, viewOrigin, and viewBasis are required");
         }
         let gsplat = this.readSplat.apply({
           index,
@@ -747,7 +760,9 @@ export class SplatPager {
         }).gsplat;
 
         const splatCenter = dyno.splitGsplat(gsplat).outputs.center;
-        const viewDir = dyno.normalize(dyno.sub(splatCenter, viewOrigin));
+        const viewDir = dyno.normalize(
+          dyno.mul(viewBasis, dyno.sub(splatCenter, viewOrigin)),
+        );
         let rgb = evaluatePackedSH({
           coord: pagedSplatTexCoord(index),
           viewDir,
@@ -807,17 +822,20 @@ export class SplatPager {
       {
         index: "int",
         viewOrigin: "vec3",
+        viewBasis: "mat3",
         numSh: "int",
       },
       { gsplat: dyno.Gsplat },
-      ({ index, viewOrigin, numSh }) => {
-        if (!index || !viewOrigin || !numSh) {
-          throw new Error("index and viewOrigin are required");
+      ({ index, viewOrigin, viewBasis, numSh }) => {
+        if (!index || !viewOrigin || !viewBasis || !numSh) {
+          throw new Error("index, viewOrigin, and viewBasis are required");
         }
         let gsplat = this.readSplatExt.apply({ index }).gsplat;
 
         const splatCenter = dyno.splitGsplat(gsplat).outputs.center;
-        const viewDir = dyno.normalize(dyno.sub(splatCenter, viewOrigin));
+        const viewDir = dyno.normalize(
+          dyno.mul(viewBasis, dyno.sub(splatCenter, viewOrigin)),
+        );
         let rgb = evaluateExtSH({
           coord: pagedSplatTexCoord(index),
           viewDir,


### PR DESCRIPTION
## Summary
- Add an object-space view basis to `SplatMesh` for reflected spherical-harmonic evaluation.
- Apply the basis consistently to packed, extended, and paged/LOD splat sources.
- Add a manifest-driven multi-mirror example that composites real, reflected, and mask passes from one camera snapshot.

## Why
MirrorGaussian reflects Gaussian geometry across each mirror plane, but view-dependent color also needs the corresponding reflection applied to the SH view direction. Without this transform, reflected geometry has incorrect view-dependent appearance.

## How
`SplatMesh` exposes a `shViewBasis` matrix and passes it into every directional splat fetch path before SH evaluation. The example loads one reflected scene and mask per manifest mirror, waits for each Spark renderer to sort against the same camera snapshot, and composites the resulting render targets. It disables LOD in the example because independently updated LOD trees can put the passes at different camera states.

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`

Made with [Cursor](https://cursor.com)