### PR TITLE
Add rust/ folder to build-dist.yml paths

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'src/**'
+      - 'rust/**'
 
 jobs:
   build-dist:


### PR DESCRIPTION
As mentioned in https://github.com/sparkjsdev/spark/pull/398#issuecomment-5080732338 changes to the Rust code doesn't automatically trigger the `build-dist` action. As a result, any change that is purely on the Rust side won't be accessible in a prebuilt form automatically.

Strictly speaking there are parts of the Rust code that don't end up in the bundle, like the `build-lod` command. But trying to limit this is likely going to cause more issues than its worth. Not to mention changes to the shared `spark-lib` could still result in false positive rebuilds.