### PR TITLE
Call `super.dispose()` in Object3D subclasses for Three.js r186

### DIFF
--- a/src/SparkRenderer.ts
+++ b/src/SparkRenderer.ts
@@ -672,6 +672,9 @@ export class SparkRenderer extends THREE.Mesh {
   }
 
   dispose() {
+    // @ts-ignore Object3D has a dispose method in Three.js >= r186
+    super.dispose?.();
+
     if (this.target) {
       this.target.dispose();
       this.target = undefined;

--- a/src/SplatMesh.ts
+++ b/src/SplatMesh.ts
@@ -563,6 +563,9 @@ export class SplatMesh extends SplatGenerator {
   // Call this when you are finished with the SplatMesh and want to free
   // any buffers it holds (via packedSplats).
   dispose() {
+    // @ts-ignore Object3D has a dispose method in Three.js >= r186
+    super.dispose?.();
+
     if (
       this.splats &&
       this.splats !== this.packedSplats &&


### PR DESCRIPTION
There are a few descendant classes of Object3D in Spark that have their own `dispose` method. In the upcoming r186 release of Three.js, the base class will have a `dispose` method as well, so derived classes should call it (see https://github.com/mrdoob/three.js/pull/34141).

This PR adds conditional calls to the base `dispose` method if present. This way the same code will work for the currently supported Three.js versions as well as the upcoming r186 and later. Since the types don't know about this new `dispose` method the `@ts-ignore` annotations are required.