### PR TITLE
Add GLSL langauge hint before shader string literals

### DIFF
--- a/examples/glsl/index.html
+++ b/examples/glsl/index.html
@@ -68,7 +68,7 @@
     butterfly.worldModifier = new dyno.Dyno({
       inTypes: { gsplat: dyno.Gsplat },
       outTypes: { gsplat: dyno.Gsplat },
-      globals: () => [dyno.unindent(`
+      globals: () => [dyno.unindent(/* glsl */ `
         vec3 waveRgb(vec3 pos) {
           return vec3(
             0.6 + 0.4 * sin(pos.x * 56.0),
@@ -77,7 +77,7 @@
           );
         }
       `)],
-      statements: ({ inputs, outputs }) => dyno.unindentLines(`
+      statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
         ${outputs.gsplat} = ${inputs.gsplat};
         ${outputs.gsplat}.rgba.rgb *= waveRgb(${inputs.gsplat}.center);
       `),
@@ -98,7 +98,7 @@
           inTypes: { gsplat: dyno.Gsplat, t: "float" },
           outTypes: { gsplat: dyno.Gsplat },
           globals: () => [
-            dyno.unindent(`
+            dyno.unindent(/* glsl */ `
               float warpRadial(float r, float t) {
                 return r * (1.0 + 0.1 * sin(r * 15.0 + t * 3.0));
               }
@@ -109,7 +109,7 @@
               }
             `)
           ],
-          statements: ({ inputs, outputs }) => dyno.unindentLines(`
+          statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             ${outputs.gsplat}.center = warp(${inputs.gsplat}.center, ${inputs.t});
           `),

--- a/examples/interactive-deform/main.js
+++ b/examples/interactive-deform/main.js
@@ -124,7 +124,7 @@ function createDragBounceDynoshader() {
         },
         outTypes: { gsplat: dyno.Gsplat },
         statements: ({ inputs, outputs }) =>
-          dyno.unindentLines(`
+          dyno.unindentLines(/* glsl */ `
           ${outputs.gsplat} = ${inputs.gsplat};
           vec3 originalPos = ${inputs.gsplat}.center;
           

--- a/examples/interactive-holes/index.html
+++ b/examples/interactive-holes/index.html
@@ -127,7 +127,7 @@
             inTypes: inputTypes,
             outTypes: { gsplat: dyno.Gsplat },
             globals: () => [
-              dyno.unindent(`
+              dyno.unindent(/* glsl */ `
               float hash(vec3 p) { return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453); }
               vec3 simulatePhysics(vec3 originalPos, float dropTime, float gravity, float damping, float floorLevel, float friction, float explosionStrength) {
                 float timeVariation = hash(originalPos + vec3(42.0)) * 0.2 - 0.1;
@@ -160,7 +160,7 @@
               }
             `),
             ],
-            statements: ({ inputs, outputs }) => dyno.unindentLines(`
+            statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
               ${outputs.gsplat} = ${inputs.gsplat};
               vec3 originalPos = ${inputs.gsplat}.center;
               const int K = ${MAX_IMPULSES};

--- a/examples/interactive-ripples/main.js
+++ b/examples/interactive-ripples/main.js
@@ -55,7 +55,7 @@ function passthroughDyno(timeUniform, hitpointUniform) {
         },
         outTypes: { gsplat: dyno.Gsplat },
         globals: () => [
-          dyno.unindent(`
+          dyno.unindent(/* glsl */ `
            vec3 shockwave(vec3 center, float t, vec3 hitpoint) {
              vec3 direction = center - hitpoint;
              float distance = length(direction);
@@ -73,7 +73,7 @@ function passthroughDyno(timeUniform, hitpointUniform) {
         `),
         ],
         statements: ({ inputs, outputs }) =>
-          dyno.unindentLines(`
+          dyno.unindentLines(/* glsl */ `
           ${outputs.gsplat} = ${inputs.gsplat};
           // Apply shockwave function to position
           ${outputs.gsplat}.center = shockwave(${inputs.gsplat}.center, ${inputs.time}, ${inputs.hitpoint});

--- a/examples/lofi/index.html
+++ b/examples/lofi/index.html
@@ -519,7 +519,7 @@
         inTypes: { gsplat1: dyno.Gsplat, gsplat2: dyno.Gsplat, t: "float", translate: "float" },
         outTypes: { gsplat: dyno.Gsplat },
         inputs,
-        statements: ({ inputs, outputs }) => dyno.unindentLines(`
+        statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
           ${outputs.gsplat} = ${inputs.gsplat1};
           vec3 center2 = ${inputs.gsplat2}.center + vec3(0.0, 0.0, ${inputs.translate});
           ${outputs.gsplat}.center = mix(${inputs.gsplat1}.center, center2, ${inputs.t});
@@ -535,7 +535,7 @@
         inTypes: { gsplat: dyno.Gsplat, rustleBlend: "float", t: "float" },
         outTypes: { gsplat: dyno.Gsplat },
         inputs: { gsplat, rustleBlend, t },
-        globals: () => [dyno.unindent(`
+        globals: () => [dyno.unindent(/* glsl */ `
           vec4 colorWave(vec4 rgba, vec3 p, float t) {
             float len = length(p);
             float magnitude = sin(len + t + 1.7 * p.x + 2.3 * p.z + 0.9 * p.y);
@@ -547,7 +547,7 @@
             return mix(rgba, target, 1.0 - sqr(1.0 - magnitude));
           }
         `)],
-        statements: ({ inputs, outputs }) => dyno.unindentLines(`
+        statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
           ${outputs.gsplat} = ${inputs.gsplat};
           vec4 displace = colorWave(${outputs.gsplat}.rgba, ${outputs.gsplat}.center, ${inputs.t});
           displace.w = 1.0 - displace.w;
@@ -562,7 +562,7 @@
         outTypes: { gsplat: dyno.Gsplat },
         inputs: { gsplat, tips },
         statements: ({ inputs, outputs }) => {
-          return dyno.unindentLines(`
+          return dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             vec3 center = ${outputs.gsplat}.center;
 
@@ -598,7 +598,7 @@
         inTypes: { gsplat: dyno.Gsplat, spotlightOrigins: "vec3", spotlightDirs: "vec3", spotlightFovs: "float" },
         outTypes: { gsplat: dyno.Gsplat },
         inputs: { gsplat, spotlightOrigins, spotlightDirs, spotlightFovs },
-        globals: () => [dyno.unindent(`
+        globals: () => [dyno.unindent(/* glsl */ `
           float computeSpotlight(
             vec3 worldVertex,
             vec3 worldOrigin,
@@ -635,7 +635,7 @@
           }
         `)],
         statements: ({ inputs, outputs }) => {
-          return dyno.unindentLines(`
+          return dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             if (${inputs.spotlightFovs}[0] > 0.0 || ${inputs.spotlightFovs}[1] > 0.0) {
               float lighting = 0.0;

--- a/examples/render-cube-depth/index.html
+++ b/examples/render-cube-depth/index.html
@@ -94,7 +94,7 @@
         inTypes: { gsplat: dyno.Gsplat, worldToProj: "mat4" },
         outTypes: { gsplat: dyno.Gsplat },
         inputs: { gsplat, worldToProj },
-        globals: () => [dyno.unindent(`
+        globals: () => [dyno.unindent(/* glsl */ `
           const float PackUpscale = 256. / 255.; // fraction -> 0..1 (including 1)
           const float ShiftRight8 = 1. / 256.;
           const float Inv255 = 1. / 255.;
@@ -113,7 +113,7 @@
             return vec3( vuf * Inv255, gf * PackUpscale, bf );
           }
         `)],
-        statements: ({ inputs, outputs }) => dyno.unindentLines(`
+        statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
           ${outputs.gsplat}.flags = 0u;
           if (isGsplatActive(${inputs.gsplat}.flags) && (${inputs.gsplat}.rgba.a > ${minAlpha})) {
             ${outputs.gsplat} = ${inputs.gsplat};

--- a/examples/splat-dissolve-effects/index.html
+++ b/examples/splat-dissolve-effects/index.html
@@ -68,14 +68,14 @@
 				},
 				outTypes: { gsplat: dyno.Gsplat },
 				globals: () => [
-					dyno.unindent(`
+					dyno.unindent(/* glsl */ `
             vec3 hash(vec3 p) {
               return fract(sin(p*123.456)*123.456);
             }
             `),
 				],
 				statements: ({ inputs, outputs }) =>
-					dyno.unindentLines(`
+					dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             vec3 localPos = ${inputs.gsplat}.center;
             vec3 hashVal = hash(localPos);

--- a/examples/splat-flow/index.html
+++ b/examples/splat-flow/index.html
@@ -57,7 +57,7 @@
         return new dyno.Dyno({
           inTypes: { gsplat: dyno.Gsplat, inTransition: "bool", fadeIn: "bool", t: "float", gt: "float", objectIndex: "int", fixedMinScale: "bool", waves: "float" },
           outTypes: { gsplat: dyno.Gsplat },
-          globals: () => [ dyno.unindent(`
+          globals: () => [ dyno.unindent(/* glsl */ `
             float hash13(vec3 p3) { p3 = fract(p3 * .1031); p3 += dot(p3, p3.yzx + 33.33); return fract((p3.x + p3.y) * p3.z); }
             float hash11(float p) { p = fract(p * .1031); p += dot(p, p + 33.33); return fract(p * p); }
             float fadeInOut(float t) { return abs(mix(-1., 1., t)); }
@@ -82,7 +82,7 @@
               return cur == idx ? .1+fadeInOut(t) : 0.0;
             }
           `) ],
-          statements: ({ inputs, outputs }) => dyno.unindentLines(`
+          statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             ${outputs.gsplat}.center = applyCenter(${inputs.gsplat}.center, ${inputs.t}, float(${inputs.gsplat}.index), ${inputs.objectIndex}, ${inputs.waves});
             ${outputs.gsplat}.scales = applyScale(${inputs.gsplat}.scales, ${inputs.t}, ${inputs.fixedMinScale});
@@ -177,7 +177,7 @@
           return localCenter.add(m.position);
         });
 
-        const centerGLSL = `
+        const centerGLSL = /* glsl */ `
           vec3 getCenterOfMass(int idx) {
             if (idx == 0) return vec3(${centers[0].x}, ${centers[0].y}, ${centers[0].z});
             if (idx == 1) return vec3(${centers[1].x}, ${centers[1].y}, ${centers[1].z});

--- a/examples/splat-portal/main.js
+++ b/examples/splat-portal/main.js
@@ -93,7 +93,7 @@ function makePortalMaterial() {
       waveFrequency: { value: 50.0 },
       edgeSoftness: { value: 0.2 },
     },
-    vertexShader: `
+    vertexShader: /* glsl */ `
       varying vec3 vWorldPosition;
       varying vec2 vLocalXY;
       void main() {
@@ -103,7 +103,7 @@ function makePortalMaterial() {
         gl_Position = projectionMatrix * viewMatrix * worldPos;
       }
     `,
-    fragmentShader: `
+    fragmentShader: /* glsl */ `
       uniform sampler2D tMap;
       uniform mat4 portalPV;
       uniform mat4 portalBridge;

--- a/examples/splat-reveal-effects/index.html
+++ b/examples/splat-reveal-effects/index.html
@@ -158,7 +158,7 @@
           outTypes: { gsplat: dyno.Gsplat },
           // GLSL utility functions for effects
           globals: () => [
-            dyno.unindent(`
+            dyno.unindent(/* glsl */ `
               // Pseudo-random hash function
               vec3 hash(vec3 p) {
                 p = fract(p * 0.3183099 + 0.1);
@@ -221,7 +221,7 @@
             `)
           ],
           // Main effect shader logic
-          statements: ({ inputs, outputs }) => dyno.unindentLines(`
+          statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             float t = ${inputs.t};
             float s = smoothstep(0.,10.,t-4.5)*10.;

--- a/examples/splat-shader-effects/index.html
+++ b/examples/splat-shader-effects/index.html
@@ -83,7 +83,7 @@
           },
           outTypes: { gsplat: dyno.Gsplat },
           globals: () => [
-            dyno.unindent(`
+            dyno.unindent(/* glsl */ `
               vec3 hash(vec3 p) {
                 return fract(sin(p*123.456)*123.456);
               }
@@ -168,7 +168,7 @@
               }
             `)
           ],
-          statements: ({ inputs, outputs }) => dyno.unindentLines(`
+          statements: ({ inputs, outputs }) => dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             
             vec3 localPos = ${inputs.gsplat}.center;

--- a/examples/splat-transitions/effects/explosion.js
+++ b/examples/splat-transitions/effects/explosion.js
@@ -74,7 +74,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
           },
           outTypes: { gsplat: dyno.Gsplat },
           globals: () => [
-            dyno.unindent(`
+            dyno.unindent(/* glsl */ `
             mat2 rot(float angle) { float c = cos(angle); float s = sin(angle); return mat2(c, -s, s, c); }
             float hash(vec3 p) { return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453); }
             vec3 simulatePhysics(vec3 originalPos, float dropTime, float progress, float gravity, float damping, float floorLevel, float randomOffset, float friction, float explosionStrength) {
@@ -123,7 +123,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
           `),
           ],
           statements: ({ inputs, outputs }) =>
-            dyno.unindentLines(`
+            dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             vec3 originalPos = ${inputs.gsplat}.center;
             vec3 originalScale = ${inputs.gsplat}.scales;
@@ -183,12 +183,12 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
           },
           outTypes: { gsplat: dyno.Gsplat },
           globals: () => [
-            dyno.unindent(`
+            dyno.unindent(/* glsl */ `
             float hash(vec3 p) { return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453); }
           `),
           ],
           statements: ({ inputs, outputs }) =>
-            dyno.unindentLines(`
+            dyno.unindentLines(/* glsl */ `
             ${outputs.gsplat} = ${inputs.gsplat};
             vec3 originalPos = ${inputs.gsplat}.center;
             vec3 originalScale = ${inputs.gsplat}.scales;

--- a/examples/splat-transitions/effects/flow.js
+++ b/examples/splat-transitions/effects/flow.js
@@ -52,7 +52,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
       },
       outTypes: { gsplat: dyno.Gsplat },
       globals: () => [
-        dyno.unindent(`
+        dyno.unindent(/* glsl */ `
         float hash13(vec3 p3) { p3 = fract(p3 * .1031); p3 += dot(p3, p3.yzx + 33.33); return fract((p3.x + p3.y) * p3.z); }
         float hash11(float p) { p = fract(p * .1031); p += dot(p, p + 33.33); return fract(p * p); }
         float fadeInOut(float t) { return abs(mix(-1., 1., t)); }
@@ -79,7 +79,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
       `),
       ],
       statements: ({ inputs, outputs }) =>
-        dyno.unindentLines(`
+        dyno.unindentLines(/* glsl */ `
         ${outputs.gsplat} = ${inputs.gsplat};
         ${outputs.gsplat}.center = applyCenter(${inputs.gsplat}.center, ${inputs.t}, float(${inputs.gsplat}.index), ${inputs.objectIndex}, ${inputs.waves});
         ${outputs.gsplat}.scales = applyScale(${inputs.gsplat}.scales, ${inputs.t}, ${inputs.fixedMinScale});
@@ -179,7 +179,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
     return localCenter.add(m.position);
   });
 
-  const centerGLSL = `
+  const centerGLSL = /* glsl */ `
     vec3 getCenterOfMass(int idx) {
       if (idx == 0) return vec3(${centers[0].x}, ${centers[0].y}, ${centers[0].z});
       if (idx == 1) return vec3(${centers[1].x}, ${centers[1].y}, ${centers[1].z});

--- a/examples/splat-transitions/effects/morph.js
+++ b/examples/splat-transitions/effects/morph.js
@@ -43,7 +43,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
       },
       outTypes: { gsplat: dyno.Gsplat },
       globals: () => [
-        dyno.unindent(`
+        dyno.unindent(/* glsl */ `
         vec3 hash3(int n) {
           float x = float(n);
           return fract(sin(vec3(x, x + 1.0, x + 2.0)) * 43758.5453123);
@@ -59,7 +59,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
       `),
       ],
       statements: ({ inputs, outputs }) =>
-        dyno.unindentLines(`
+        dyno.unindentLines(/* glsl */ `
         ${outputs.gsplat} = ${inputs.gsplat};
         float stay = ${inputs.stay};
         float trans = ${inputs.trans};

--- a/examples/splat-transitions/effects/spheric.js
+++ b/examples/splat-transitions/effects/spheric.js
@@ -89,7 +89,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
       },
       outTypes: { gsplat: dyno.Gsplat },
       globals: () => [
-        dyno.unindent(`
+        dyno.unindent(/* glsl */ `
         vec3 applyCenter(vec3 center, float t, float spereRadius, float sphereHeight) {
           float heightModifier = 0.5 + 0.5 * pow(abs(1.0 - 2.0*t), 0.2);
           vec3 targetCenter = vec3(0.0, heightModifier * sphereHeight, 0.0);
@@ -132,7 +132,7 @@ export async function init({ THREE: _THREE, scene, camera, renderer, spark }) {
       `),
       ],
       statements: ({ inputs, outputs }) =>
-        dyno.unindentLines(`
+        dyno.unindentLines(/* glsl */ `
         ${outputs.gsplat} = ${inputs.gsplat};
         ${outputs.gsplat}.center = applyCenter(${inputs.gsplat}.center, ${inputs.t}, ${inputs.spereRadius}, ${inputs.sphereHeight});
         ${outputs.gsplat}.scales = applyScale(${inputs.gsplat}.scales, ${inputs.t}, ${inputs.splatScale});

--- a/src/ExtSplats.ts
+++ b/src/ExtSplats.ts
@@ -778,7 +778,7 @@ export class DynoExtSplats extends DynoUniform<
   }
 }
 
-export const defineEvaluateExtSH1 = unindent(`
+export const defineEvaluateExtSH1 = unindent(/* glsl */ `
   vec3 evaluateExtSH1(uvec4 packedData, vec3 viewDir) {
     vec3 sh1_0 = decodeExtRgb(packedData.x);
     vec3 sh1_1 = decodeExtRgb(packedData.y);
@@ -790,7 +790,7 @@ export const defineEvaluateExtSH1 = unindent(`
   }
 `);
 
-export const defineEvaluateExtSH12 = unindent(`
+export const defineEvaluateExtSH12 = unindent(/* glsl */ `
   vec3 evaluateExtSH12(uvec4 packed1, uvec4 packed2, vec3 viewDir) {
     vec3 sh1_0 = decodeExtRgb(packed1.x);
     vec3 sh1_1 = decodeExtRgb(packed1.y);
@@ -816,7 +816,7 @@ export const defineEvaluateExtSH12 = unindent(`
   }
 `);
 
-export const defineEvaluateExtSH3 = unindent(`
+export const defineEvaluateExtSH3 = unindent(/* glsl */ `
   vec3 evaluateExtSH3(uvec4 packedA, uvec4 packedB, vec3 viewDir) {
     vec3 sh3_0 = decodeExtRgb(packedA.x);
     vec3 sh3_1 = decodeExtRgb(packedA.y);
@@ -890,7 +890,7 @@ export function evaluateExtSH({
       if (inputs.sh1Texture) {
         if (!inputs.sh2Texture) {
           lines.push(
-            ...unindentLines(`
+            ...unindentLines(/* glsl */ `
             if (${inputs.numSh} >= 1) {
               rgb = evaluateExtSH1(texelFetch(${inputs.sh1Texture}, ${inputs.coord}, 0), ${inputs.viewDir});
             }
@@ -898,7 +898,7 @@ export function evaluateExtSH({
           );
         } else {
           lines.push(
-            ...unindentLines(`
+            ...unindentLines(/* glsl */ `
             if (${inputs.numSh} == 1) {
               rgb = evaluateExtSH1(texelFetch(${inputs.sh1Texture}, ${inputs.coord}, 0), ${inputs.viewDir});
             } else if (${inputs.numSh} >= 2) {
@@ -908,7 +908,7 @@ export function evaluateExtSH({
 
           if (inputs.sh3TextureA && inputs.sh3TextureB) {
             lines.push(
-              ...unindentLines(`
+              ...unindentLines(/* glsl */ `
               if (${inputs.numSh} >= 3) {
                 rgb += evaluateExtSH3(texelFetch(${inputs.sh3TextureA}, ${inputs.coord}, 0), texelFetch(${inputs.sh3TextureB}, ${inputs.coord}, 0), ${inputs.viewDir});
               }

--- a/src/PackedSplats.ts
+++ b/src/PackedSplats.ts
@@ -1068,7 +1068,7 @@ export class DynoPackedSplats extends DynoUniform<
   }
 }
 
-export const defineEvalPackedSH1 = unindent(`
+export const defineEvalPackedSH1 = unindent(/* glsl */ `
   vec3 evaluatePackedSH1(uvec2 packedData, vec3 viewDir, float sh1Max) {
     // Extract sint7 values packed into 2 x uint32
     vec3 sh1_0 = vec3(ivec3(
@@ -1094,7 +1094,7 @@ export const defineEvalPackedSH1 = unindent(`
   }
 `);
 
-export const defineEvalPackedSH2 = unindent(`
+export const defineEvalPackedSH2 = unindent(/* glsl */ `
   vec3 evaluatePackedSH2(uvec4 packedData, vec3 viewDir, float sh2Max) {
     // Extract sint8 values packed into 4 x uint32
     vec3 sh2_0 = vec3(ivec3(
@@ -1132,7 +1132,7 @@ export const defineEvalPackedSH2 = unindent(`
   }
 `);
 
-export const defineEvalPackedSH3 = unindent(`
+export const defineEvalPackedSH3 = unindent(/* glsl */ `
   vec3 evaluatePackedSH3(uvec4 packedData, vec3 viewDir, float sh3Max) {
     // Extract sint6 values packed into 4 x uint32
     vec3 sh3_0 = vec3(ivec3(
@@ -1235,7 +1235,7 @@ export function evaluatePackedSH({
       const lines = ["vec3 rgb = vec3(0.0);"];
       if (inputs.sh1Texture) {
         lines.push(
-          ...unindentLines(`
+          ...unindentLines(/* glsl */ `
           if (${inputs.numSh} >= 1) {
             vec3 sh1Rgb = evaluatePackedSH1(texelFetch(${inputs.sh1Texture}, ${inputs.coord}, 0).rg, ${inputs.viewDir}, ${inputs.shMax}.x);
             rgb += sh1Rgb;
@@ -1243,7 +1243,7 @@ export function evaluatePackedSH({
         );
         if (inputs.sh2Texture) {
           lines.push(
-            ...unindentLines(`
+            ...unindentLines(/* glsl */ `
             if (${inputs.numSh} >= 2) {
               vec3 sh2Rgb = evaluatePackedSH2(texelFetch(${inputs.sh2Texture}, ${inputs.coord}, 0), ${inputs.viewDir}, ${inputs.shMax}.y);
               rgb += sh2Rgb;
@@ -1251,7 +1251,7 @@ export function evaluatePackedSH({
           );
           if (inputs.sh3Texture) {
             lines.push(
-              ...unindentLines(`
+              ...unindentLines(/* glsl */ `
               if (${inputs.numSh} >= 3) {
                 vec3 sh3Rgb = evaluatePackedSH3(texelFetch(${inputs.sh3Texture}, ${inputs.coord}, 0), ${inputs.viewDir}, ${inputs.shMax}.z);
                 rgb += sh3Rgb;

--- a/src/RgbaArray.ts
+++ b/src/RgbaArray.ts
@@ -263,7 +263,7 @@ export class RgbaArray {
 
 export const TRgbaArray = { type: "RgbaArray" } as { type: "RgbaArray" };
 
-export const defineRgbaArray = unindent(`
+export const defineRgbaArray = unindent(/* glsl */ `
   struct RgbaArray {
     sampler2DArray texture;
     int count;
@@ -283,7 +283,7 @@ export function readRgbaArray(
     inputs: { rgba, index },
     globals: () => [defineRgbaArray],
     statements: ({ inputs, outputs }) =>
-      unindentLines(`
+      unindentLines(/* glsl */ `
         if ((${inputs.index} >= 0) && (${inputs.index} < ${inputs.rgba}.count)) {
           ${outputs.rgba} = texelFetch(${inputs.rgba}.texture, splatTexCoord(${inputs.index}), 0);
         } else {

--- a/src/SparkPortals.ts
+++ b/src/SparkPortals.ts
@@ -6,7 +6,7 @@ import { SparkRenderer, type SparkRendererOptions } from "./SparkRenderer";
  * - diskRadius > 0: render "behind portal" only through the disk
  * - diskRadius < 0: render "in front of portal" everywhere except behind disk
  */
-export const DISK_PORTAL_FRAGMENT_SHADER = `
+export const DISK_PORTAL_FRAGMENT_SHADER = /* glsl */ `
 precision highp float;
 precision highp int;
 

--- a/src/SplatAccumulator.ts
+++ b/src/SplatAccumulator.ts
@@ -623,7 +623,7 @@ export class SplatAccumulator {
               },
               statements: ({ inputs, outputs }) => {
                 if (this.extSplats) {
-                  return unindentLines(`
+                  return unindentLines(/* glsl */ `
                     int indexDiv8 = ${inputs.index} >> 3;
                     ivec3 coord = splatTexCoord(indexDiv8);
                     uvec4 packedData;
@@ -641,7 +641,7 @@ export class SplatAccumulator {
                     ${outputs.rgba8} = uintToVec4(data);
                   `);
                 }
-                return unindentLines(`
+                return unindentLines(/* glsl */ `
                   int indexDiv4 = ${inputs.index} >> 2;
                   ivec3 coord = splatTexCoord(indexDiv4);
                   uvec4 packedData = texelFetch(${inputs.extSplats1}, coord, 0);

--- a/src/SplatEdit.ts
+++ b/src/SplatEdit.ts
@@ -566,7 +566,7 @@ export class SplatEdits {
 
 export const SdfArray = { type: "SdfArray" } as { type: "SdfArray" };
 
-export const defineSdfArray = unindent(`
+export const defineSdfArray = unindent(/* glsl */ `
   struct SdfArray {
     int numSdfs;
     usampler2D sdfTexture;
@@ -733,7 +733,7 @@ export const defineSdfArray = unindent(`
   }
 `);
 
-export const defineEdit = unindent(`
+export const defineEdit = unindent(/* glsl */ `
   const uint EDIT_FLAG_BLEND = 0xFFu;
   const uint EDIT_BLEND_MULTIPLY = 0u;
   const uint EDIT_BLEND_SET_RGB = 1u;
@@ -820,7 +820,7 @@ function applyGsplatRgbaDisplaceEdits(
     statements: ({ inputs, outputs }) => {
       const { sdfArray, numEdits, rgbaDisplaceEdits } = inputs;
       const { gsplat } = outputs;
-      return unindentLines(`
+      return unindentLines(/* glsl */ `
         ${gsplat} = ${inputs.gsplat};
         if (isGsplatActive(${gsplat}.flags)) {
           for (int editIndex = 0; editIndex < ${numEdits}; ++editIndex) {
@@ -863,7 +863,7 @@ function applyCovSplatRgbaDisplaceEdits(
     statements: ({ inputs, outputs }) => {
       const { sdfArray, numEdits, rgbaDisplaceEdits } = inputs;
       const { covsplat } = outputs;
-      return unindentLines(`
+      return unindentLines(/* glsl */ `
         ${covsplat} = ${inputs.covsplat};
         if (isCovSplatActive(${covsplat}.flags)) {
           for (int editIndex = 0; editIndex < ${numEdits}; ++editIndex) {

--- a/src/SplatGenerator.ts
+++ b/src/SplatGenerator.ts
@@ -183,7 +183,7 @@ export class CovSplatTransformer {
         if (!covsplat || !basis || !offset) {
           return [`${outputs.covsplat}.flags = 0u;`];
         }
-        return unindentLines(`
+        return unindentLines(/* glsl */ `
           ${outputs.covsplat}.flags = 0u;
           if (isCovSplatActive(${covsplat}.flags)) {
             ${outputs.covsplat}.flags = ${covsplat}.flags;

--- a/src/SplatMesh.ts
+++ b/src/SplatMesh.ts
@@ -200,7 +200,7 @@ export class EmptySplatSource implements SplatSource {
     outTypes: { gsplat: Gsplat },
     globals: () => [defineGsplat],
     statements: ({ outputs }) =>
-      unindentLines(`
+      unindentLines(/* glsl */ `
       ${outputs.gsplat}.flags = 0u;
       return;
     `),
@@ -1218,7 +1218,7 @@ export function maybeLookupIndex(
       showLodPage,
     },
     statements: ({ inputs, outputs }) =>
-      unindentLines(`
+      unindentLines(/* glsl */ `
         int index = ${inputs.index};
         if (${inputs.showLodPage} < 0) {
           if (index >= ${inputs.numSplats}) {
@@ -1258,7 +1258,7 @@ export function maybeInjectSplatRgba(
     outTypes: { gsplat: Gsplat },
     inputs: { gsplat, rgba, index, enableLod },
     statements: ({ inputs, outputs }) =>
-      unindentLines(`
+      unindentLines(/* glsl */ `
         ${outputs.gsplat} = ${inputs.gsplat};
         if (!${inputs.enableLod} && (${inputs.index} >= 0) && (${inputs.index} < ${inputs.rgba}.count)) {
           ${outputs.gsplat}.rgba = texelFetch(${inputs.rgba}.texture, splatTexCoord(${inputs.index}), 0);

--- a/src/SplatPager.ts
+++ b/src/SplatPager.ts
@@ -666,7 +666,7 @@ export class SplatPager {
             indices,
           },
           statements: ({ inputs, outputs }) =>
-            dyno.unindentLines(`
+            dyno.unindentLines(/* glsl */ `
             if (${inputs.index} >= ${inputs.numSplats}) {
               return;
             }
@@ -699,7 +699,7 @@ export class SplatPager {
           },
           globals: () => [dyno.defineGsplat],
           statements: ({ inputs, outputs }) =>
-            dyno.unindentLines(`
+            dyno.unindentLines(/* glsl */ `
             int index = ${inputs.index};
             ivec3 splatCoord = pagedSplatTexCoord(index);
             uvec4 packedData = texelFetch(${inputs.packedTexture}, splatCoord, 0);
@@ -788,7 +788,7 @@ export class SplatPager {
           },
           globals: () => [dyno.defineGsplat],
           statements: ({ inputs, outputs }) =>
-            dyno.unindentLines(`
+            dyno.unindentLines(/* glsl */ `
             int index = ${inputs.index};
             ivec3 splatCoord = ivec3(index & 255, (index >> 8) & 255, index >> 16);
             uvec4 ext1 = texelFetch(${inputs.extTexture1}, splatCoord, 0);

--- a/src/SplatSkinning.ts
+++ b/src/SplatSkinning.ts
@@ -326,7 +326,7 @@ export const GsplatSkinning = { type: "GsplatSkinning" } as {
   type: "GsplatSkinning";
 };
 
-export const defineGsplatSkinning = unindent(`
+export const defineGsplatSkinning = unindent(/* glsl */ `
   struct GsplatSkinning {
     int numSplats;
     int numBones;
@@ -335,7 +335,7 @@ export const defineGsplatSkinning = unindent(`
   };
 `);
 
-export const defineApplyGsplatSkinning = unindent(`
+export const defineApplyGsplatSkinning = unindent(/* glsl */ `
   void applyGsplatSkinning(
     int numSplats, int numBones,
     usampler2DArray skinTexture, sampler2D boneTexture,
@@ -411,7 +411,7 @@ function applyGsplatSkinning(
     statements: ({ inputs, outputs }) => {
       const { skinning } = inputs;
       const { gsplat } = outputs;
-      return unindentLines(`
+      return unindentLines(/* glsl */ `
         ${gsplat} = ${inputs.gsplat};
         if (isGsplatActive(${gsplat}.flags)) {
           applyGsplatSkinning(
@@ -426,7 +426,7 @@ function applyGsplatSkinning(
   return dyno.outputs.gsplat;
 }
 
-export const defineApplyCovSplatDQSkinning = unindent(`
+export const defineApplyCovSplatDQSkinning = unindent(/* glsl */ `
   void applyCovSplatDQSkinning(
     int numSplats, int numBones,
     usampler2DArray skinTexture, sampler2D boneTexture,
@@ -492,7 +492,7 @@ export const defineApplyCovSplatDQSkinning = unindent(`
   }
 `);
 
-export const defineApplyCovSplatLBSkinning = unindent(`
+export const defineApplyCovSplatLBSkinning = unindent(/* glsl */ `
   void applyCovSplatLBSkinning(
     int numSplats, int numBones,
     usampler2DArray skinTexture, sampler2D boneTexture,
@@ -556,7 +556,7 @@ function applyCovSplatDQSkinning(
     statements: ({ inputs, outputs }) => {
       const { skinning } = inputs;
       const { covsplat } = outputs;
-      return unindentLines(`
+      return unindentLines(/* glsl */ `
         ${covsplat} = ${inputs.covsplat};
         if (isCovSplatActive(${covsplat}.flags)) {
           applyCovSplatDQSkinning(
@@ -586,7 +586,7 @@ function applyCovSplatLBSkinning(
     statements: ({ inputs, outputs }) => {
       const { skinning } = inputs;
       const { covsplat } = outputs;
-      return unindentLines(`
+      return unindentLines(/* glsl */ `
         ${covsplat} = ${inputs.covsplat};
         if (isCovSplatActive(${covsplat}.flags)) {
           applyCovSplatLBSkinning(

--- a/src/dyno/output.ts
+++ b/src/dyno/output.ts
@@ -59,7 +59,7 @@ export class OutputPackedSplat extends Dyno<
       statements: ({ inputs, outputs }) => {
         const { gsplat, rgbMinMaxLnScaleMinMax } = inputs;
         if (gsplat && rgbMinMaxLnScaleMinMax) {
-          return unindentLines(`
+          return unindentLines(/* glsl */ `
             if (isGsplatActive(${gsplat}.flags)) {
               target = packSplatEncoding(${gsplat}.center, ${gsplat}.scales, ${gsplat}.quaternion, ${gsplat}.rgba, ${rgbMinMaxLnScaleMinMax});
             } else {
@@ -91,7 +91,7 @@ export class OutputCovSplat extends Dyno<
       statements: ({ inputs }) => {
         const { covsplat, rgbMinMaxLnScaleMinMax } = inputs;
         if (covsplat && rgbMinMaxLnScaleMinMax) {
-          return unindentLines(`
+          return unindentLines(/* glsl */ `
             if (isCovSplatActive(${covsplat}.flags)) {
               target = packSplatCovEncoding(${covsplat}.center, ${covsplat}.rgba, ${covsplat}.xxyyzz, ${covsplat}.xyxzyz, ${rgbMinMaxLnScaleMinMax});
             } else {
@@ -121,7 +121,7 @@ export class OutputExtendedSplat extends Dyno<
       statements: ({ inputs }) => {
         const { gsplat } = inputs;
         if (gsplat) {
-          return unindentLines(`
+          return unindentLines(/* glsl */ `
             if (isGsplatActive(${gsplat}.flags)) {
               packSplatExt(target, target2, ${gsplat}.center, ${gsplat}.scales, ${gsplat}.quaternion, ${gsplat}.rgba);
             } else {
@@ -152,7 +152,7 @@ export class OutputExtCovSplat extends Dyno<
       statements: ({ inputs }) => {
         const { covsplat } = inputs;
         if (covsplat) {
-          return unindentLines(`
+          return unindentLines(/* glsl */ `
             if (isCovSplatActive(${covsplat}.flags)) {
               packSplatExtCov(target, target2, ${covsplat}.center, ${covsplat}.rgba, ${covsplat}.xxyyzz, ${covsplat}.xyxzyz);
             } else {
@@ -199,7 +199,7 @@ class OutputSplatDepth extends Dyno<
       statements: ({ inputs }) => {
         const { gsplat, viewCenter, viewDir, sortRadial } = inputs;
         if (gsplat && viewCenter && viewDir && sortRadial) {
-          return unindentLines(`
+          return unindentLines(/* glsl */ `
             float metric = 1.0 / 0.0;
             if (isGsplatActive(${gsplat}.flags)) {
               vec3 center = ${gsplat}.center - ${viewCenter};
@@ -251,7 +251,7 @@ class OutputCovSplatDepth extends Dyno<
       statements: ({ inputs }) => {
         const { covsplat, viewCenter, viewDir, sortRadial } = inputs;
         if (covsplat && viewCenter && viewDir && sortRadial) {
-          return unindentLines(`
+          return unindentLines(/* glsl */ `
             float metric = 1.0 / 0.0;
             if (isCovSplatActive(${covsplat}.flags)) {
               vec3 center = ${covsplat}.center - ${viewCenter};

--- a/src/dyno/splats.ts
+++ b/src/dyno/splats.ts
@@ -132,7 +132,7 @@ export const splatTexCoord = (index: DynoVal<"int">): DynoVal<"ivec3"> =>
 export const pagedSplatTexCoord = (index: DynoVal<"int">): DynoVal<"ivec3"> =>
   new PagedSplatTexCoord({ index });
 
-export const defineGsplat = unindent(`
+export const defineGsplat = unindent(/* glsl */ `
   struct Gsplat {
     vec3 center;
     uint flags;
@@ -148,7 +148,7 @@ export const defineGsplat = unindent(`
   }
 `);
 
-export const defineCovSplat = unindent(`
+export const defineCovSplat = unindent(/* glsl */ `
   struct CovSplat {
     vec3 center;
     uint flags;
@@ -163,7 +163,7 @@ export const defineCovSplat = unindent(`
   }
 `);
 
-export const definePackedSplats = unindent(`
+export const definePackedSplats = unindent(/* glsl */ `
   struct PackedSplats {
     usampler2DArray textureArray;
     int numSplats;
@@ -187,7 +187,7 @@ export class NumPackedSplats extends UnaryOp<
   }
 }
 
-const defineReadPackedArray = unindent(`
+const defineReadPackedArray = unindent(/* glsl */ `
   bool readPackedArray(usampler2DArray texture, int numSplats, vec4 rgbMinMaxLnScaleMinMax, int index, out Gsplat gsplat) {
     if ((index >= 0) && (index < numSplats)) {
       uvec4 packedData = texelFetch(texture, splatTexCoord(index), 0);
@@ -223,7 +223,7 @@ export class ReadPackedSplat
         const { packedSplats, index } = inputs;
         let statements: string[];
         if (packedSplats && index) {
-          statements = unindentLines(`
+          statements = unindentLines(/* glsl */ `
             ${gsplat}.flags = 0u;
             if (readPackedArray(${packedSplats}.textureArray, ${packedSplats}.numSplats, ${packedSplats}.rgbMinMaxLnScaleMinMax, ${index}, ${gsplat})) {
               if (${packedSplats}.lodOpacity) {
@@ -288,7 +288,7 @@ export class ReadPackedSplatRange
         const { packedSplats, index, base, count } = inputs;
         let statements: string[];
         if (packedSplats && index && base && count) {
-          statements = unindentLines(`
+          statements = unindentLines(/* glsl */ `
             ${gsplat}.flags = 0u;
             if (readPackedArray(${packedSplats}.textureArray, ${packedSplats}.numSplats, ${packedSplats}.rgbMinMaxLnScaleMinMax, ${index}, ${gsplat})) {
               if (${packedSplats}.lodOpacity) {
@@ -312,7 +312,7 @@ export class ReadPackedSplatRange
   }
 }
 
-export const defineExtSplats = unindent(`
+export const defineExtSplats = unindent(/* glsl */ `
   struct ExtSplats {
     usampler2DArray textureArray1;
     usampler2DArray textureArray2;
@@ -333,7 +333,7 @@ export class NumExtSplats extends UnaryOp<
   }
 }
 
-const defineReadExtArrays = unindent(`
+const defineReadExtArrays = unindent(/* glsl */ `
   void readExtArrays(usampler2DArray texture1, usampler2DArray texture2, int numSplats, int index, out Gsplat gsplat) {
     gsplat.flags = 0u;
     if ((index >= 0) && (index < numSplats)) {
@@ -371,7 +371,7 @@ export class ReadExtSplat
         const { extSplats, index } = inputs;
         let statements: string[];
         if (extSplats && index) {
-          return unindentLines(`
+          return unindentLines(/* glsl */ `
             readExtArrays(${extSplats}.textureArray1, ${extSplats}.textureArray2, ${extSplats}.numSplats, ${index}, ${gsplat});
           `);
         }
@@ -398,7 +398,7 @@ export class NumCovSplats extends UnaryOp<
   }
 }
 
-const defineReadCovArrays = unindent(`
+const defineReadCovArrays = unindent(/* glsl */ `
   void readCovArrays(usampler2DArray texture1, usampler2DArray texture2, int numSplats, int index, out CovSplat covsplat) {
     covsplat.flags = 0u;
     if ((index >= 0) && (index < numSplats)) {
@@ -436,7 +436,7 @@ export class ReadCovSplat
         const { covSplats, index } = inputs;
         let statements: string[];
         if (covSplats && index) {
-          return unindentLines(`
+          return unindentLines(/* glsl */ `
             readCovArrays(${covSplats}.textureArray, ${covSplats}.numSplats, ${index}, ${covsplat});
           `);
         }
@@ -467,7 +467,7 @@ export class GsplatToCovSplat extends Dyno<
           return [`${covsplat}.flags = 0u;`];
         }
 
-        return unindentLines(`
+        return unindentLines(/* glsl */ `
           ${covsplat}.flags = 0u;
           if (isGsplatActive(${gsplat}.flags)) {
             ${covsplat}.flags = ${gsplat}.flags;
@@ -726,7 +726,7 @@ export class CombineGsplat
   }
 }
 
-export const defineGsplatNormal = unindent(`
+export const defineGsplatNormal = unindent(/* glsl */ `
   vec3 gsplatNormal(vec3 scales, vec4 quaternion) {
     float minScale = min(scales.x, min(scales.y, scales.z));
     vec3 normal;

--- a/src/dyno/util.ts
+++ b/src/dyno/util.ts
@@ -119,7 +119,7 @@ export class PcgNext<T extends "uint" | "int" | "float">
       outTypes: { state: "uint" },
       inputs: { state },
       globals: () => [
-        unindent(`
+        unindent(/* glsl */ `
           uint pcg_next(uint state) {
             return state * 747796405u + 2891336453u;
           }
@@ -151,7 +151,7 @@ export class PcgHash
       outTypes: { hash: "uint" },
       inputs: { state },
       globals: () => [
-        unindent(`
+        unindent(/* glsl */ `
           uint pcg_hash(uint state) {
             uint hash = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
             return (hash >> 22u) ^ hash;
@@ -180,7 +180,7 @@ export class PcgMix<T extends ValueTypes>
       outTypes: { state: "uint" },
       inputs: { value },
       globals: () => [
-        unindent(`
+        unindent(/* glsl */ `
           uint pcg_mix(uint value) {
             return value;
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -934,7 +934,7 @@ export function omitUndefined<T extends object>(obj: T): Partial<T> {
 }
 
 // "Identity" vertex shader that just passes through the position.
-export const IDENT_VERTEX_SHADER = unindent(`
+export const IDENT_VERTEX_SHADER = unindent(/* glsl */ `
   precision highp float;
 
   in vec3 position;


### PR DESCRIPTION
This PR prefixes all string/template literals containing GLSL code with a language hint (`/* glsl */`). IDEs can pick these up to provide syntax highlighting and other language features. Since it's effectively a normal comment block, this has no impact on IDEs without support for it.

FWIW, Three.js uses these as well in their code base. And since Spark has some large raw GLSL chunks throughout the code and examples, it doesn't hurt having syntax highlighting.