### PR TITLE
Add gsplatXaxis/Yaxis/Zaxis helper dynos

### DIFF
--- a/docs/docs/dyno-stdlib.md
+++ b/docs/docs/dyno-stdlib.md
@@ -232,4 +232,7 @@ This way, you can pass around a `DynoVal<Gsplat>` that contains the all the prop
 | `splitGsplat(gsplat)` | Split a `Gsplat` into its components |
 | `combineGsplat(gsplat)` | Create a `Gsplat` from components (or inject components into an existing `Gsplat`) |
 | `gsplatNormal(gsplat)` | Get the `Gsplat` normal, defined as whichever X/Y/Z axis has the smallest scale |
+| `gsplatXAxis(gsplat)` | Return the unit vector along the splat's X-axis |
+| `gsplatYAxis(gsplat)` | Return the unit vector along the splat's Y-axis |
+| `gsplatZAxis(gsplat)` | Return the unit Vector along the splat's Z-axis |
 | `transformGsplat(gsplat, { scale?, rotate?, translate?, recolor? })` | Transform a `Gsplat` and all its components by the given transform |

--- a/src/dyno/splats.ts
+++ b/src/dyno/splats.ts
@@ -108,6 +108,12 @@ export const combineGsplat = ({
 };
 export const gsplatNormal = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
   new GsplatNormal({ gsplat });
+export const gsplatXaxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
+  new GsplatXaxis({ gsplat });
+export const gsplatYaxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
+  new GsplatYaxis({ gsplat });
+export const gsplatZaxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
+  new GsplatZaxis({ gsplat });
 
 export const transformGsplat = (
   gsplat: DynoVal<typeof Gsplat>,
@@ -747,6 +753,36 @@ export class GsplatNormal extends UnaryOp<typeof Gsplat, "vec3", "normal"> {
     this.globals = () => [defineGsplat, defineGsplatNormal];
     this.statements = ({ inputs, outputs }) => [
       `${outputs.normal} = gsplatNormal(${inputs.a}.scales, ${inputs.a}.quaternion);`,
+    ];
+  }
+}
+
+export class GsplatXaxis extends UnaryOp<typeof Gsplat, "vec3", "xaxis"> {
+  constructor({ gsplat }: { gsplat: DynoVal<typeof Gsplat> }) {
+    super({ a: gsplat, outKey: "xaxis", outTypeFunc: () => "vec3" });
+    this.globals = () => [defineGsplat];
+    this.statements = ({ inputs, outputs }) => [
+      `${outputs.xaxis} = quatVec(${inputs.a}.quaternion, vec3(1.0, 0.0, 0.0));`,
+    ];
+  }
+}
+
+export class GsplatYaxis extends UnaryOp<typeof Gsplat, "vec3", "yaxis"> {
+  constructor({ gsplat }: { gsplat: DynoVal<typeof Gsplat> }) {
+    super({ a: gsplat, outKey: "yaxis", outTypeFunc: () => "vec3" });
+    this.globals = () => [defineGsplat];
+    this.statements = ({ inputs, outputs }) => [
+      `${outputs.yaxis} = quatVec(${inputs.a}.quaternion, vec3(0.0, 1.0, 0.0));`,
+    ];
+  }
+}
+
+export class GsplatZaxis extends UnaryOp<typeof Gsplat, "vec3", "zaxis"> {
+  constructor({ gsplat }: { gsplat: DynoVal<typeof Gsplat> }) {
+    super({ a: gsplat, outKey: "zaxis", outTypeFunc: () => "vec3" });
+    this.globals = () => [defineGsplat];
+    this.statements = ({ inputs, outputs }) => [
+      `${outputs.zaxis} = quatVec(${inputs.a}.quaternion, vec3(0.0, 0.0, 1.0));`,
     ];
   }
 }

--- a/src/dyno/splats.ts
+++ b/src/dyno/splats.ts
@@ -108,12 +108,12 @@ export const combineGsplat = ({
 };
 export const gsplatNormal = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
   new GsplatNormal({ gsplat });
-export const gsplatXaxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
-  new GsplatXaxis({ gsplat });
-export const gsplatYaxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
-  new GsplatYaxis({ gsplat });
-export const gsplatZaxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
-  new GsplatZaxis({ gsplat });
+export const gsplatXAxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
+  new GsplatXAxis({ gsplat });
+export const gsplatYAxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
+  new GsplatYAxis({ gsplat });
+export const gsplatZAxis = (gsplat: DynoVal<typeof Gsplat>): DynoVal<"vec3"> =>
+  new GsplatZAxis({ gsplat });
 
 export const transformGsplat = (
   gsplat: DynoVal<typeof Gsplat>,
@@ -757,7 +757,7 @@ export class GsplatNormal extends UnaryOp<typeof Gsplat, "vec3", "normal"> {
   }
 }
 
-export class GsplatXaxis extends UnaryOp<typeof Gsplat, "vec3", "xaxis"> {
+export class GsplatXAxis extends UnaryOp<typeof Gsplat, "vec3", "xaxis"> {
   constructor({ gsplat }: { gsplat: DynoVal<typeof Gsplat> }) {
     super({ a: gsplat, outKey: "xaxis", outTypeFunc: () => "vec3" });
     this.globals = () => [defineGsplat];
@@ -767,7 +767,7 @@ export class GsplatXaxis extends UnaryOp<typeof Gsplat, "vec3", "xaxis"> {
   }
 }
 
-export class GsplatYaxis extends UnaryOp<typeof Gsplat, "vec3", "yaxis"> {
+export class GsplatYAxis extends UnaryOp<typeof Gsplat, "vec3", "yaxis"> {
   constructor({ gsplat }: { gsplat: DynoVal<typeof Gsplat> }) {
     super({ a: gsplat, outKey: "yaxis", outTypeFunc: () => "vec3" });
     this.globals = () => [defineGsplat];
@@ -777,7 +777,7 @@ export class GsplatYaxis extends UnaryOp<typeof Gsplat, "vec3", "yaxis"> {
   }
 }
 
-export class GsplatZaxis extends UnaryOp<typeof Gsplat, "vec3", "zaxis"> {
+export class GsplatZAxis extends UnaryOp<typeof Gsplat, "vec3", "zaxis"> {
   constructor({ gsplat }: { gsplat: DynoVal<typeof Gsplat> }) {
     super({ a: gsplat, outKey: "zaxis", outTypeFunc: () => "vec3" });
     this.globals = () => [defineGsplat];


### PR DESCRIPTION
The dyno helper `gsplatNormal` computes the minimum of the X/Y/Z splat axis and returns a unit vector in that direction, which in some cases can be used as a proxy for a "normal". However, sometimes your splats are always oriented such that the Z-axis points in that direction. In that case it can be useful to have an additional dyno helper like `gsplatZaxis`, which returns a unit vector in that direction. This PR adds this helper and the symmetric `gsplatXaxis`/`gsplatYaxis` as well.