### PR TITLE
Fix Rust workspace license metadata to MIT

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.82"
 edition = "2021"
-license = "Proprietary"
+license = "MIT"
 authors = ["World Labs Technologies"]
 repository = "https://github.com/sparkjs-dev/spark"
 


### PR DESCRIPTION
Updates the Rust workspace license declaration to match the repository’s
MIT LICENSE. The build-lod, spark-lib, and spark-rs crates inherit this value.